### PR TITLE
Don't set CODEOWNERS yet

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*	@rohanpm @rajulkumar


### PR DESCRIPTION
This repo is still undergoing initial development and code review
is not yet enforcing. Don't set CODEOWNERS for the time being,
otherwise it will spam owners for every incoming PR.