### PR TITLE
Fix build of docs in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,8 +50,9 @@ commands=
 
 [testenv:docs]
 deps=
-	sphinx
-	alabaster
+    sphinx
+    alabaster
+    rpm-py-installer
 use_develop=true
 commands=
 	sphinx-build -M html docs docs/_build


### PR DESCRIPTION
We need to install rpm-py-installer for docs target too.