### PR TITLE
koji: fix handling of build & rpm IDs

### DIFF
--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -13,7 +13,7 @@ from more_executors.futures import f_map
 
 from ..source import Source
 from ..model import RpmPushItem, ModuleMdPushItem
-from pushsource.helpers import list_argument
+from pushsource.helpers import list_argument, try_int
 
 LOG = logging.getLogger("pushsource")
 CACHE_LOCK = threading.RLock()
@@ -159,9 +159,8 @@ class KojiSource(Source):
                 A custom executor used to submit calls to koji.
         """
         self._url = url
-        # TODO: do IDs actually work for these? Doesn't against fedkoji...
-        self._rpm = list_argument(rpm)
-        self._module_build = list_argument(module_build)
+        self._rpm = [try_int(x) for x in list_argument(rpm)]
+        self._module_build = [try_int(x) for x in list_argument(module_build)]
         self._signing_key = list_argument(signing_key)
         self._dest = list_argument(dest)
         self._timeout = timeout

--- a/src/pushsource/_impl/helpers.py
+++ b/src/pushsource/_impl/helpers.py
@@ -26,3 +26,28 @@ def list_argument(value):
     if isinstance(value, six.string_types):
         return value.split(",")
     return [value]
+
+
+def try_int(value):
+    """Convert strings into integers where possible.
+
+    This function is intended for use in :class:`~pushsource.Source` constructors
+    to ease the processing of arguments passed via URL.
+
+    Parameters:
+        value
+            Any value.
+
+    Returns:
+        int
+            ``value`` converted to an integer, if it was a string representation
+            of an integer.
+        other
+            ``value`` unmodified, in any other case.
+    """
+    if not isinstance(value, six.string_types):
+        return value
+    try:
+        return int(value)
+    except ValueError:
+        return value

--- a/src/pushsource/helpers.py
+++ b/src/pushsource/helpers.py
@@ -2,6 +2,6 @@
 a :class:`~pushsource.Source` class.
 """
 
-from pushsource._impl.helpers import list_argument
+from pushsource._impl.helpers import list_argument, try_int
 
-__all__ = ["list_argument"]
+__all__ = ["list_argument", "try_int"]


### PR DESCRIPTION
If the source is given an integer-like string by URL, it must be
converted into a real integer before use in an XML-RPC call to
koji.