### PR TITLE
Make pushsource.helpers private

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -98,8 +98,7 @@ To implement a backend, follow these steps:
 * Create a class inheriting from :class:`~pushsource.Source`.
 * In your constructor, add any arguments you'd like to be usable in URLs for your backend,
   while following these conventions:
-    * Remember that all arguments from URLs will be provided as strings. Use conversions
-      from :mod:`~pushsource.helpers` where needed.
+    * Remember that all arguments from URLs will be provided as strings.
     * Accept a `url` argument if and only if you want your backend URL to accept a URL
       immediately after the backend scheme (as in example ``backend:url?arg=val&arg=val&...``).
     * If your backend uses a customizable number of threads, use an argument named `threads`

--- a/src/pushsource/_impl/backend/errata_source.py
+++ b/src/pushsource/_impl/backend/errata_source.py
@@ -12,7 +12,7 @@ from more_executors.futures import f_map, f_zip
 from .. import compat_attr as attr
 from ..source import Source
 from ..model import ErratumPushItem
-from pushsource.helpers import list_argument
+from ..helpers import list_argument
 
 LOG = logging.getLogger("pushsource")
 

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -13,7 +13,7 @@ from more_executors.futures import f_map
 
 from ..source import Source
 from ..model import RpmPushItem, ModuleMdPushItem
-from pushsource.helpers import list_argument, try_int
+from ..helpers import list_argument, try_int
 
 LOG = logging.getLogger("pushsource")
 CACHE_LOCK = threading.RLock()

--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -15,10 +15,9 @@ from pushcollector import Collector
 from more_executors import Executors
 
 from ...source import Source
+from ...helpers import list_argument
+
 from .staged_utils import StagingMetadata, StagingLeafDir
-
-from pushsource.helpers import list_argument
-
 from .staged_ami import StagedAmiMixin
 from .staged_files import StagedFilesMixin
 from .staged_errata import StagedErrataMixin

--- a/src/pushsource/helpers.py
+++ b/src/pushsource/helpers.py
@@ -1,7 +1,0 @@
-"""The helpers module provides helper functions intended for use in implementing
-a :class:`~pushsource.Source` class.
-"""
-
-from pushsource._impl.helpers import list_argument, try_int
-
-__all__ = ["list_argument", "try_int"]

--- a/tests/helpers/test_argument_helpers.py
+++ b/tests/helpers/test_argument_helpers.py
@@ -1,4 +1,4 @@
-from pushsource.helpers import list_argument
+from pushsource._impl.helpers import list_argument
 
 
 def test_list_argument():


### PR DESCRIPTION
The helpers module is intended to include functions which assist
in implementing new sources, mainly to do with parsing arguments
from URLs.

I don't feel confident in this API, as the contents are fairly
arbitrary according to the sources which have been implemented so
far.  Let's make it private for now so we don't have to commit
to maintaining compatibility.