### PR TITLE
Define and enforce a schema for staging metadata

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,6 +106,10 @@ html_theme_options = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+# Copy schema files to top-level so that there is a stable location for
+# schemas, making them consumable elsewhere
+html_extra_path = ["../src/pushsource/_impl/schema"]
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ A library for accessing push items from various sources.
    model/productid
    model/comps
    model/channeldumps
+   schema/staged
 
 Quick Start
 -----------

--- a/docs/schema/staged.rst
+++ b/docs/schema/staged.rst
@@ -1,0 +1,18 @@
+.. _staging_schema:
+
+Schema: staged
+==============
+
+This document shows the schema of metadata files used within the
+:ref:`staging_structure` supported by this library, in
+`JSON schema`_ format.
+
+The latest version of this schema is available in raw form at
+https://release-engineering.github.io/pushsource/staged-schema.yaml.
+
+
+.. include:: ../../src/pushsource/_impl/schema/staged-schema.yaml
+    :code: yaml
+
+
+.. _JSON schema: https://json-schema.org/

--- a/src/pushsource/_impl/backend/staged/staged_files.py
+++ b/src/pushsource/_impl/backend/staged/staged_files.py
@@ -18,6 +18,7 @@ class StagedFilesMixin(StagedBaseMixin):
             name=file_md.filename or entry.name,
             src=entry.path,
             description=file_md.attributes.get("description"),
+            version=file_md.version,
             sha256sum=file_md.sha256sum,
             origin=leafdir.topdir,
             dest=[leafdir.dest],

--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -81,10 +81,6 @@ class StagedSource(
             timeout
         )
 
-        #         FILE_TYPE_PATHS = {
-        #     'aws_image': ['AWS_IMAGES'],  # waiting on DEVOPSA-6421
-        # }
-
     def __iter__(self):
         """Iterate over push items."""
 

--- a/src/pushsource/_impl/model/file.py
+++ b/src/pushsource/_impl/model/file.py
@@ -8,3 +8,13 @@ class FilePushItem(PushItem):
 
     description = attr.ib(type=str, default=None)
     """A human-readable brief description of the file."""
+
+    version = attr.ib(type=str, default=None)
+    """A version string associated with the file.
+
+    This string is intended for display purposes only.
+    It may denote a product version associated with this file.
+    For example, a push item for ``oc-4.2.33-linux.tar.gz`` may
+    use a version of ``"4.2.33"`` to denote that the file relates
+    to OpenShift version 4.2.33.
+    """

--- a/src/pushsource/_impl/schema/__init__.py
+++ b/src/pushsource/_impl/schema/__init__.py
@@ -1,0 +1,12 @@
+import yaml
+import os
+
+
+SCHEMA_PATH = os.path.dirname(__file__)
+
+
+def get_schema(name):
+    filename = "%s-schema.yaml" % name
+    path = os.path.join(SCHEMA_PATH, filename)
+    with open(path) as f:
+        return yaml.load(f, Loader=yaml.SafeLoader)

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -1,0 +1,306 @@
+---
+# Schema for metadata file "staged.yaml" or "pub-mapfile.json"
+# accompanying a staged source.
+#
+# For general information about staging directories, see:
+# https://release-engineering.github.io/pushsource/sources/staged.html
+#
+
+$schema: http://json-schema.org/draft-07/schema#
+$id: http://release-engineering.github.io/pushsource/staged-schema.yaml
+
+
+###############################################################################
+#  Subschemas
+definitions:
+
+    header:
+        type: object
+        properties:
+            version:
+                # Version of the file format.
+                # There is only a single supported version now.
+                const: "0.2"
+
+        requiredProperties:
+        - version
+
+        additionalProperties: false
+
+    payload:
+        type: object
+        properties:
+            files:
+                $ref: "#/definitions/file_list"
+        additionalProperties: false
+
+    attributes_any:
+        type: object
+        anyOf:
+        - $ref: "#/definitions/attributes_channel_dump"
+        - $ref: "#/definitions/attributes_ami"
+        - $ref: "#/definitions/attributes_file"
+
+    attributes_channel_dump:
+        # Attributes for channel dump ISO images.
+        properties:
+            allowed_eng_products:
+                oneOf:
+                    # Comma-separated IDs of products with content in this channel dump.
+                    - type: string
+                      pattern: "^[0-9,]+"
+
+                    # Or, real integer IDs.
+                    - type: array
+                      items:
+                        type: integer
+                        minimum: 1
+
+            channel_dump_arch:
+                # Architecture of this channel dump
+                type: string
+                minLength: 2
+
+            channel_dump_content:
+                # TODO: what is this?
+                type: string
+                minLength: 1
+
+            channel_dump_date:
+                # ISO8601 timestamp at which this dump was generated
+                type: string
+                minLength: 1
+
+            channel_dump_disc_number:
+                # Disc number. Starts counting at 1; values greater than 1
+                # will be observed for channel dumps spanning multiple disc
+                # images.
+                type: integer
+                minimum: 1
+
+            channel_dump_included_channels:
+                oneOf:
+
+                    # Comma-separated list of channel names included in this dump
+                    - type: string
+                      minLength: 1
+
+                    # Or, an actual list.
+                    - type: array
+                      items:
+                        type: string
+                        minLength: 1
+
+            channel_dump_product_name:
+                # Short name of product associated with this dump
+                # TODO: clarify meaning
+                type: string
+                minLength: 1
+
+            channel_dump_product_version:
+                # Product version associated with this dump
+                # TODO: clarify meaning
+                type: string
+                minLength: 1
+
+            channel_dump_type:
+                # 'base' if this channel dump can be used standalone,
+                # 'incremental' if it is intended to be combined with earlier
+                # channel dumps
+                type: string
+                enum:
+                - base
+                - incremental
+
+            description:
+                # Brief human-readable string summarizing this channel dump
+                type: string
+                minLength: 1
+                maxLength: 1000
+
+        required:
+        - allowed_eng_products
+        - channel_dump_arch
+        - channel_dump_content
+        - channel_dump_date
+        - channel_dump_included_channels
+        - channel_dump_product_name
+        - channel_dump_product_version
+        - channel_dump_type
+        - description
+
+        additionalProperties: false
+
+    attributes_ami:
+        # Attributes for Amazon Machine Images (AMIs).
+        properties:
+
+            release:
+                $ref: "#/definitions/ami_release"
+
+            region:
+                # AWS region to which this AMI should be pushed.
+                type: string
+                minLength: 1
+
+            type:
+                # Billing type for the image.
+                type: string
+                enum:
+                - hourly
+                - access
+
+            virtualization:
+                # Virtualization type.
+                type: string
+                enum:
+                - hvm
+
+            volume:
+                type: string
+                enum:
+                - standard
+                - gp2
+                - io1
+                - st1
+                - sc1
+
+            root_device:
+                type: string
+                minLength: 1
+
+            description:
+                $ref: "#/definitions/optional_string"
+
+            sriov_net_support:
+                type:
+                - string
+                - "null"
+                enum:
+                - simple
+                - null
+
+            ena_support:
+                type:
+                - boolean
+                - "null"
+
+        required:
+        - release
+        - region
+        - type
+        - virtualization
+        - volume
+        - root_device
+
+        additionalProperties: false
+
+    attributes_file:
+        # Attributes for generic files.
+        properties:
+
+            description:
+                # Human-readable brief description of the file, e.g.
+                # appropriate for use in a file browsing UI
+                type: string
+                minLength: 1
+
+        required:
+        - description
+        additionalProperties: false
+
+    file_list:
+        type: array
+        items:
+            $ref: "#/definitions/file"
+        uniqueItems: true
+
+    file:
+        type: object
+        properties:
+            filename:
+                # Desired name of this file on the target system.
+                # Need not match the filename used in the staging area.
+                type: string
+                minLength: 1
+
+            relative_path:
+                # Relative path to the file being pushed within the staging
+                # area.
+                type: string
+                minLength: 3
+
+            sha256sum:
+                # SHA256 checksum of this file's content, as a hex digest.
+                type: string
+                minLength: 64
+                maxLength: 64
+                pattern: "^[0-9a-fA-F]+$"
+
+            version:
+                # A version string for display purposes
+                # TODO: missing from model?
+                type: string
+                minLength: 1
+
+            attributes:
+                # Additional metadata, differs per content type.
+                $ref: "#/definitions/attributes_any"
+
+        additionalProperties: false
+
+    ami_release:
+        # Release metadata for an AMI.
+        type: object
+        properties:
+            product:
+                type: string
+                minLength: 1
+            version:
+                $ref: "#/definitions/optional_string"
+            base_product:
+                $ref: "#/definitions/optional_string"
+            base_version:
+                $ref: "#/definitions/optional_string"
+            variant:
+                $ref: "#/definitions/optional_string"
+            arch:
+                type: string
+                enum:
+                - arm64
+                - x86_64
+            respin:
+                type: integer
+            type:
+                $ref: "#/definitions/optional_string"
+                enum: ['ga', 'beta', null]
+            date:
+                type: string
+                minLength: 1
+                pattern: "^[0-9]{8}$"
+        required:
+        - product
+        - date
+        - arch
+        - respin
+
+    optional_string:
+        # A field which may hold a non-empty string, or null.
+        type:
+        - string
+        - "null"
+        minLength: 1
+
+###############################################################################
+#  Main schema
+type: object
+properties:
+    header:
+        $ref: "#/definitions/header"
+    payload:
+        $ref: "#/definitions/payload"
+
+required:
+- header
+
+additionalProperties: false

--- a/tests/staged/data/dupe_meta/staged.yaml
+++ b/tests/staged/data/dupe_meta/staged.yaml
@@ -1,5 +1,5 @@
 header:
-    version: 0.2
+    version: "0.2"
 
 payload:
     files:

--- a/tests/staged/data/incomplete_channel_dumps/staged.yaml
+++ b/tests/staged/data/incomplete_channel_dumps/staged.yaml
@@ -1,5 +1,5 @@
 header:
-    version: 0.2
+    version: "0.2"
 
 payload:
     files:

--- a/tests/staged/data/simple_channel_dumps/staged.yaml
+++ b/tests/staged/data/simple_channel_dumps/staged.yaml
@@ -1,5 +1,5 @@
 header:
-    version: 0.2
+    version: "0.2"
 
 payload:
     files:

--- a/tests/staged/data/simple_files/staged.yaml
+++ b/tests/staged/data/simple_files/staged.yaml
@@ -1,5 +1,5 @@
 header:
-    version: 0.2
+    version: "0.2"
 
 payload:
     files:
@@ -14,6 +14,7 @@ payload:
     - filename: some-file.txt
       relative_path: dest2/FILES/some-file
       sha256sum: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
+      version: 1.2.3
 
     # a file with some attributes
     - filename: some-iso

--- a/tests/staged/test_staged_basic.py
+++ b/tests/staged/test_staged_basic.py
@@ -1,6 +1,7 @@
 import os
 
 from pytest import raises
+from jsonschema import ValidationError
 
 from pushsource import Source
 
@@ -41,10 +42,8 @@ def test_staged_no_header_metadata(tmpdir):
     empty.join("pub-mapfile.json").write("{}")
     source = Source.get("staged:%s" % empty)
 
-    with raises(ValueError) as exc_info:
+    with raises(ValidationError) as exc_info:
         list(source)
-
-    assert "pub-mapfile.json has unsupported version" in str(exc_info.value)
 
 
 def test_staged_dupe_metadata():

--- a/tests/staged/test_staged_simple_files.py
+++ b/tests/staged/test_staged_simple_files.py
@@ -39,6 +39,7 @@ def test_staged_simple_files():
             build=None,
             signing_key=None,
             description=None,
+            version="1.2.3",
         ),
         FilePushItem(
             name="some-iso",


### PR DESCRIPTION
staged.yaml / pub-mapfile.json is now validated against a documented
schema. Implementing this schema also uncovered missing support for
a 'version' attribute, which was fixed.