### PR TITLE
Drop doc strings for __iter__ methods

### DIFF
--- a/src/pushsource/_impl/backend/errata_source.py
+++ b/src/pushsource/_impl/backend/errata_source.py
@@ -211,14 +211,6 @@ class ErrataSource(Source):
         return out
 
     def __iter__(self):
-        """Iterate over push items for the given errata.
-
-        - Yields :ref:`~pushsource.ErratumPushItem` instances for erratum metadata
-        - Yields :ref:`~pushsource.RpmPushItem` instances for RPMs
-
-        Other content types are not yet supported (most notably, container images).
-        """
-
         # Get file list of all advisories first.
         #
         # We get the file list first because it contains koji build NVRs,

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -337,11 +337,6 @@ class KojiSource(Source):
             raise
 
     def __iter__(self):
-        """Iterate over push items.
-
-        - Yields :ref:`~pushsource.RpmPushItem` instances for RPMs
-        """
-
         # Queue holding all requests we need to make to koji.
         # We try to fetch as much as we can early to make efficient use
         # of multicall.

--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -82,8 +82,6 @@ class StagedSource(
         )
 
     def __iter__(self):
-        """Iterate over push items."""
-
         # Possible improvement would be to handle the separate dirs concurrently.
         # However, may not be worthwhile, as  in practice I'm not sure the ability
         # to pass more than a single staging directory is ever used (?)


### PR DESCRIPTION
The meaning is always the same as on the base class, and these
doc strings don't make it into the generated HTML docs anyway.