### PR TITLE
docs: fix incorrect usage of koji_source in example

### DIFF
--- a/docs/sources/errata.rst
+++ b/docs/sources/errata.rst
@@ -47,7 +47,7 @@ content, such as ``rpm``, blank - the errata source will fill them in as needed)
 For example, if our ET environment is connected to Fedora Koji, we could configure
 this as:
 
-``errata:https://errata.example.com?errata=RHBA-2020:1234&koji_source=https://koji.fedoraproject.org/kojihub``
+``errata:https://errata.example.com?errata=RHBA-2020:1234&koji_source=koji:https://koji.fedoraproject.org/kojihub``
 
 Although it is technically possible to configure the koji source behavior using
 any of the parameters documented in :ref:`source_koji`, in practice this results


### PR DESCRIPTION
koji_source needs a full valid source URL, not just a koji URL
(as a different kind of source could potentially be used).
It should be "koji:\<koji-hub-url\>" and not just "\<koji-hub-url\>".