### PR TITLE
Fix crash on null id/title in erratum references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+- Fix too strict schema on erratum references; id and title are allowed to be null.
 
 ## 1.0.0 - 2020-06-16
 

--- a/src/pushsource/_impl/model/erratum.py
+++ b/src/pushsource/_impl/model/erratum.py
@@ -21,10 +21,10 @@ class ErratumReference(object):
     href = attr.ib(type=str, validator=instance_of_str)
     """A URL."""
 
-    id = attr.ib(type=str, validator=instance_of_str)
+    id = attr.ib(type=str, validator=optional_str)
     """A short ID for the reference, unique within this erratum."""
 
-    title = attr.ib(type=str, validator=instance_of_str)
+    title = attr.ib(type=str, validator=optional_str)
     """A title for the reference; analogous to the 'title' attribute
     in HTML.
     """

--- a/src/pushsource/_impl/schema/errata-schema.yaml
+++ b/src/pushsource/_impl/schema/errata-schema.yaml
@@ -21,6 +21,12 @@ definitions:
         - type: string
           pattern: "^[0-9]*$"
 
+    optional_string:
+        # A field which may hold a string, or null.
+        type:
+        - string
+        - "null"
+
     reference_list:
         type: array
         items:
@@ -33,9 +39,9 @@ definitions:
             href:
                 type: string
             id:
-                type: string
+                $ref: "#/definitions/optional_string"
             title:
-                type: string
+                $ref: "#/definitions/optional_string"
             type:
                 type: string
         required:

--- a/tests/staged/data/simple_errata/dest1/ERRATA/advisory2.json
+++ b/tests/staged/data/simple_errata/dest1/ERRATA/advisory2.json
@@ -8,8 +8,8 @@
     {
       "href": "https://access.redhat.com/errata/RHSA-2020:0509",
       "type": "self",
-      "id": "RHSA-2020:0509",
-      "title": "RHSA-2020:0509"
+      "id": null,
+      "title": null
     },
     {
       "href": "https://bugzilla.redhat.com/show_bug.cgi?id=1796944",

--- a/tests/staged/test_staged_simple_errata.py
+++ b/tests/staged/test_staged_simple_errata.py
@@ -154,8 +154,8 @@ def test_staged_simple_errata():
             references=[
                 ErratumReference(
                     href="https://access.redhat.com/errata/RHSA-2020:0509",
-                    id="RHSA-2020:0509",
-                    title="RHSA-2020:0509",
+                    id=None,
+                    title=None,
                     type="self",
                 ),
                 ErratumReference(


### PR DESCRIPTION
The schema/model for these fields was too strict - in reality,
the id and title fields on references are null for some errata.