### PR TITLE
koji: improve log messages on missing RPM(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Changed
+- Improved log message details in some cases of error
 
 ## 1.0.0 - 2020-06-16
 

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -206,6 +206,8 @@ class KojiSource(Source):
         unsigned_path = os.path.join(build_path, self._pathinfo.rpm(meta))
         rpm_signing_key = None
 
+        candidate_paths = []
+
         # If signing keys requested, try them in order of preference
         for key in self._signing_key:
             if key:
@@ -213,6 +215,7 @@ class KojiSource(Source):
                 candidate = os.path.join(build_path, self._pathinfo.signed(meta, key))
             else:
                 candidate = unsigned_path
+            candidate_paths.append(candidate)
             if os.path.exists(candidate):
                 rpm_path = candidate
                 rpm_signing_key = key
@@ -222,9 +225,7 @@ class KojiSource(Source):
             # If signing keys requested: we either found an RPM above, or an error occurs
             if not rpm_path:
                 LOG.error(
-                    "RPM not found in koji with signing key(s) %s: %s",
-                    ", ".join([str(x) for x in self._signing_key]),
-                    rpm,
+                    "RPM not found in koji at path(s): %s", ", ".join(candidate_paths)
                 )
                 return notfound
         else:

--- a/tests/koji/test_koji.py
+++ b/tests/koji/test_koji.py
@@ -217,10 +217,12 @@ def test_koji_missing_signing_key(fake_koji, koji_dir, caplog):
     assert items == [RpmPushItem(name="foo-1.0-1.x86_64.rpm", state="NOTFOUND")]
 
     # ...for this reason
-    assert (
-        "RPM not found in koji with signing key(s) abc123: foo-1.0-1.x86_64.rpm"
-        in caplog.messages
+    expected_path = (
+        "%s/vol/somevol/packages/foobuild/1.0/1.el8/data/signed/abc123/x86_64/foo-1.0-1.x86_64.rpm"
+        % koji_dir
     )
+    expected_msg = "RPM not found in koji at path(s): %s" % expected_path
+    assert expected_msg in caplog.messages
 
 
 def test_koji_uses_signing_key(fake_koji, koji_dir, caplog):


### PR DESCRIPTION
When we can't find a requested RPM on the filesystem, previously
we'd log that RPMs were not found but it wasn't clear what it
means. Adjust the error message to include the paths of the missing
RPM(s) to make it more obvious.