### PR TITLE
Fix crash on python2 if using get_partial with register_backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+- Fix crash on Python 2 if using `get_partial` and `register_backend` together
 
 ## 1.0.0 - 2020-06-16
 

--- a/src/pushsource/_impl/source.py
+++ b/src/pushsource/_impl/source.py
@@ -130,7 +130,12 @@ class Source(object):
 
         url_kwargs.update(kwargs)
 
-        return functools.partial(klass, **url_kwargs)
+        @functools.wraps(klass)
+        def partial_source(*inner_args, **inner_kwargs):
+            url_kwargs.update(inner_kwargs)
+            return klass(*inner_args, **url_kwargs)
+
+        return partial_source
 
     @classmethod
     def register_backend(cls, name, factory):

--- a/tests/source/test_source_register.py
+++ b/tests/source/test_source_register.py
@@ -1,0 +1,11 @@
+from pushsource import Source
+
+
+def test_get_registered_partial():
+    """Can register a source obtained via get_partial, then get source using registered scheme."""
+    errata_example = Source.get_partial("errata:https://errata.example.com")
+    Source.register_backend("errata-example", errata_example)
+
+    # We should now be able to request sources using et_example scheme.
+    # We're just verifying that the call obtains a source, without crashing.
+    assert Source.get("errata-example:errata=ABC-123")


### PR DESCRIPTION
For any registered backend, the Source class needs to know if
the backend accepts a 'url' argument, which is done by inspecting
the backend's signature.

However, on Python 2, this only works on "pure" python functions,
and not the output of functools.partial. This meant that if you
obtained a callable by get_partial and then gave it to
register_backend (which is the intended use), you'd get a crash
along the lines of:

  TypeError: arg is not a Python function

Let's avoid functools.partial and instead manually bind the function
we're returning, to improve Python 2 compatibility.