### PR TITLE
Improve errors when bad source URLs are used

### DIFF
--- a/docs/sources/base.rst
+++ b/docs/sources/base.rst
@@ -6,3 +6,5 @@ The ``Source`` class is the base from which all pushsource backends derive.
 
 .. autoclass:: pushsource.Source
    :members:
+
+.. autoclass:: pushsource.SourceUrlError

--- a/src/pushsource/__init__.py
+++ b/src/pushsource/__init__.py
@@ -1,4 +1,4 @@
-from pushsource._impl import Source
+from pushsource._impl import Source, SourceUrlError
 from pushsource._impl.model import (
     PushItem,
     FilePushItem,

--- a/src/pushsource/_impl/__init__.py
+++ b/src/pushsource/_impl/__init__.py
@@ -1,3 +1,3 @@
-from .source import Source
+from .source import Source, SourceUrlError
 from .backend import ErrataSource
 from .model import PushItem, ErratumPushItem

--- a/src/pushsource/_impl/source.py
+++ b/src/pushsource/_impl/source.py
@@ -19,6 +19,12 @@ def getfullargspec(x):
     return inspect.getfullargspec(x)
 
 
+class SourceUrlError(ValueError):
+    """Errors of this type are raised when an invalid URL is provided
+    to :meth:`~pushsource.Source.get` and related methods.
+    """
+
+
 class Source(object):
     """A source of push items.
 
@@ -50,6 +56,10 @@ class Source(object):
                 Any additional keyword arguments to be passed into
                 the backend.
 
+        Raises:
+            SourceUrlError
+                If ``source_url`` is not a valid push source URL.
+
         Returns:
             :class:`~pushsource.Source`
                 A new Source instance initialized with the given arguments.
@@ -76,6 +86,10 @@ class Source(object):
                 Any additional keyword arguments to be passed into
                 the backend.
 
+        Raises:
+            SourceUrlError
+                If ``source_url`` is not a valid push source URL.
+
         Returns:
             callable
                 A callable which accepts any number of keyword arguments
@@ -83,6 +97,16 @@ class Source(object):
         """
         parsed = parse.urlparse(source_url)
         scheme = parsed.scheme
+
+        if not scheme:
+            raise SourceUrlError("Not a valid source URL: %s" % source_url)
+
+        if scheme not in cls._BACKENDS:
+            raise SourceUrlError(
+                "Requested source '%s' but there is no registered backend '%s'"
+                % (source_url, scheme)
+            )
+
         klass = cls._BACKENDS[scheme]
 
         query = parsed.query

--- a/tests/source/test_source.py
+++ b/tests/source/test_source.py
@@ -1,7 +1,7 @@
 import copy
 from pytest import raises, fixture
 
-from pushsource import Source
+from pushsource import Source, SourceUrlError
 
 
 def test_source_abstract():
@@ -46,3 +46,20 @@ def test_args_from_url():
             "foo": "bar,baz",
         },
     )
+
+
+def test_bad_url_no_scheme():
+    with raises(SourceUrlError) as ex_info:
+        Source.get("no-scheme")
+
+    assert "Not a valid source URL: no-scheme" in str(ex_info.value)
+
+
+def test_bad_url_missing_backend():
+    with raises(SourceUrlError) as ex_info:
+        Source.get("notexist:foo=bar&baz=quux")
+
+    assert (
+        "Requested source 'notexist:foo=bar&baz=quux' but "
+        "there is no registered backend 'notexist'"
+    ) in str(ex_info.value)


### PR DESCRIPTION
Previously, if a bad source URL was given, typically a confusing
KeyError would be raised. Let's use a specific type of error to
make it more clear that an incorrect URL is the source of the
problem.