### PR TITLE
Introduce PushItem.with_checksums for calculating sums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+
+- Introduced `PushItem.with_checksums` method for calculating checksums.
 
 ## [1.1.0] - 2020-06-23
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pushsource",
-    version="1.1.0",
+    version="1.2.0",
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,

--- a/src/pushsource/_impl/model/base.py
+++ b/src/pushsource/_impl/model/base.py
@@ -1,7 +1,15 @@
+import hashlib
+import os
+import logging
+
 from frozenlist2 import frozenlist
 
 from .. import compat_attr as attr
 from .conv import md5str, sha256str, upper_if_str, instance_of_str, optional_str
+
+
+LOG = logging.getLogger("pushsource")
+CHUNKSIZE = int(os.environ.get("PUSHSOURCE_CHUNKSIZE") or 1024 * 1024 * 16)
 
 
 @attr.s()
@@ -53,10 +61,20 @@ class PushItem(object):
     """
 
     md5sum = attr.ib(type=str, default=None, converter=md5str)
-    """Hex digest of MD5 checksum for this push item, if available."""
+    """Hex digest of MD5 checksum for this push item, if available.
+
+    .. seealso::
+
+        :meth:`with_checksums`
+    """
 
     sha256sum = attr.ib(type=str, default=None, converter=sha256str)
-    """Hex digest of SHA256 checksum for this push item, if available."""
+    """Hex digest of SHA256 checksum for this push item, if available.
+
+    .. seealso::
+
+        :meth:`with_checksums`
+    """
 
     origin = attr.ib(type=str, default=None, validator=optional_str)
     """A string representing the origin of this push item.
@@ -78,3 +96,74 @@ class PushItem(object):
     Generally a short key ID such as "F21541EB" is used, though the library
     doesn't enforce this.
     """
+
+    def with_checksums(self):
+        """Return a copy of this push item with checksums present.
+
+        Many pushsource backends will produce push items with empty checksum attributes,
+        since checksum calculation may be expensive and may not be required in all cases.
+
+        The rule of thumb is that a pushsource will only provide checksums if they were
+        available in metadata, so that reading the push item's file was unnecessary.
+        For example:
+
+        - with ``errata`` push source, checksums are generally available by default, because
+          Errata Tool itself provides checksums on the files contained in an advisory.
+        - with ``staged`` push source, checksums are unavailable by default, because the
+          sums can only be calculated by reading file content from the staging area.
+
+        Where checksums are needed, this utility method may be used to ensure they are present
+        regardless of the push source used.
+
+        This method entails reading the entire content of the file referenced
+        by this push item, and may be:
+
+        - slow: may need to read a large file from a remote system, e.g. from an NFS volume.
+        - error-prone: reads from a remote system might fail.
+
+        As such, when dealing with a large number of push items, you may want to consider
+        using multiple threads to parallelize calls to ``with_checksums``, and retrying
+        failing operations.
+
+        If checksums are already present or if this item does not reference a file, this
+        method is a no-op and returns the current push item, unmodified.
+
+        Returns:
+            :class:`~pushsource.PushItem`
+                A copy of this item, guaranteed either to have non-empty :meth:`md5sum` and
+                :meth:`sha256sum` attributes, or an empty :meth:`src` attribute (denoting that
+                the item does not reference a file).
+
+        .. versionadded:: 1.2.0
+        """
+        if not self.src:
+            return self
+
+        hashers = []
+
+        if not self.md5sum:
+            hashers.append((hashlib.new("md5"), "md5sum"))
+        if not self.sha256sum:
+            hashers.append((hashlib.new("sha256"), "sha256sum"))
+
+        if not hashers:
+            # Nothing to do
+            return self
+
+        LOG.debug("Start read: %s", self.src)
+
+        with open(self.src, "rb") as src_file:
+            while True:
+                chunk = src_file.read(CHUNKSIZE)
+                if not chunk:
+                    break
+                for (hasher, _) in hashers:
+                    hasher.update(chunk)
+
+        LOG.debug("End read: %s", self.src)
+
+        updated_sums = {}
+        for (hasher, attribute) in hashers:
+            updated_sums[attribute] = hasher.hexdigest()
+
+        return attr.evolve(self, **updated_sums)

--- a/tests/model/test_push_item_read_sums.py
+++ b/tests/model/test_push_item_read_sums.py
@@ -1,0 +1,84 @@
+import hashlib
+
+from pytest import raises
+from mock import patch
+
+from pushsource import PushItem
+
+
+def test_with_checksums_noop():
+    """with_checksums does nothing if sums are already present"""
+    item = PushItem(
+        name="item",
+        src="nonexistent-file",
+        md5sum="d3b07384d113edec49eaa6238ad5ff00",
+        sha256sum="49ae93732fcf8d63fe1cce759664982dbd5b23161f007dba8561862adc96d063",
+    )
+    assert item.with_checksums() is item
+
+
+def test_with_checksums_nosrc():
+    """with_checksums does nothing on file-less item"""
+    item = PushItem(name="item")
+
+    assert item.with_checksums() is item
+
+
+def test_with_checksums_read_fails():
+    """with_checksums propagates error if referenced file can't be read"""
+    with raises(Exception) as exc_info:
+        PushItem(name="item", src="file-does-not-exist").with_checksums()
+
+    # exact type and message is not verified due to py2 vs py3 differences.
+    assert "file-does-not-exist" in str(exc_info.value)
+
+
+def test_with_checksums_reads_content(tmpdir):
+    """with_checksums reads file to calculate checksums"""
+    tmpfile = tmpdir.join("somefile")
+    tmpfile.write(b"some data")
+
+    item = PushItem(name="item", src=str(tmpfile))
+    item_sums = item.with_checksums()
+
+    # Original item should be untouched
+    assert not item.md5sum
+    assert not item.sha256sum
+
+    # with_checksums output should have correct sums filled in
+    assert item_sums.md5sum == "1e50210a0202497fb79bc38b6ade6c34"
+    assert (
+        item_sums.sha256sum
+        == "1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee"
+    )
+
+
+def test_with_checksums_partial(tmpdir):
+    """with_checksums only calculates checksums of missing types"""
+
+    tmpfile = tmpdir.join("somefile")
+    tmpfile.write(b"some data")
+
+    item = PushItem(
+        name="item", src=str(tmpfile), md5sum="1e50210a0202497fb79bc38b6ade6c34"
+    )
+
+    hashlib_new = hashlib.new
+    computed_types = []
+
+    def patched_hashlib_new(hash_type):
+        computed_types.append(hash_type)
+        return hashlib_new(hash_type)
+
+    with patch("hashlib.new", new=patched_hashlib_new):
+        item_sums = item.with_checksums()
+
+    # with_checksums output should have correct sums
+    assert item_sums.md5sum == "1e50210a0202497fb79bc38b6ade6c34"
+    assert (
+        item_sums.sha256sum
+        == "1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee"
+    )
+
+    # Only sha256 should have been calculated, since md5 was already present
+    assert computed_types == ["sha256"]


### PR DESCRIPTION
As explained in doc string. Calculating checksums is potentially
expensive, and so it is not filled in implicitly by all pushsource
backends. The caller is able to control when sums are calculated

This utility method makes it simple to obtain checksums only when
needed, e.g. a Pub-style multithreaded "computing checksums" step
could be easily implemented via a threadpool executor by:

    items = executor.map(lambda i: i.with_checksums(), items)