### PR TITLE
Add test-requirements.in to improve effectiveness of dependabot

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,0 +1,15 @@
+PyYAML
+attrs
+black
+coveralls
+frozenlist2
+kobo
+koji>=1.18
+mock
+more-executors
+pre-commit
+pushcollector
+pytest
+python-dateutil
+rpm-py-installer
+six


### PR DESCRIPTION
Previously, test-requirements.in was not added to the repo.

This causes a problem: dependabot will not add entries to the
test-requirements.txt file for any new indirect dependencies
as they are introduced by upgrades to other packages. Since we
use hash checking mode, this causes CI to fail completely as the
resulting test-requirements.txt is not installable unless hashes
are present for *all* dependencies, both direct and indirect.

Adding test-requirements.in fixes this, because it causes
dependabot to run pip-compile in order to regenerate the
corresponding .txt, and pip-compile does support updating indirect
dependencies where needed, including hashes.

See also the (internal) mail https://url.corp.redhat.com/e051f38
for more context on the problem and solution.