### PR TITLE
staged: accept metadata for legacy unsupported content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- References to unsupported `DOCKER`, `CHANNEL_DUMPS` content types in staging
+  metadata files will no longer cause a validation error.
 
 ## [2.0.0] - 2020-11-04
 

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -121,7 +121,9 @@ definitions:
     file_list:
         type: array
         items:
-            $ref: "#/definitions/file"
+            anyOf:
+            - $ref: "#/definitions/file"
+            - $ref: "#/definitions/unsupported_file"
         uniqueItems: true
 
     file:
@@ -156,6 +158,18 @@ definitions:
                 $ref: "#/definitions/attributes_any"
 
         additionalProperties: false
+
+    # Metadata for legacy types of files which were previously supported
+    # and are no longer. This schema simply accepts entries for these
+    # files without validating any of the attributes other than the path.
+    unsupported_file:
+        type: object
+        properties:
+            relative_path:
+                type: string
+                pattern: "^[^/]+/(DOCKER|CHANNEL_DUMPS)/"
+        required:
+        - relative_path
 
     ami_release:
         # Release metadata for an AMI.

--- a/tests/staged/data/unsupported/staged.yaml
+++ b/tests/staged/data/unsupported/staged.yaml
@@ -1,0 +1,12 @@
+header:
+    version: "0.2"
+
+payload:
+    files:
+
+    # metadata for unsupported file type should still be able to validate
+    # regardless of the used fields
+    - filename: some-image
+      relative_path: dest2/DOCKER/dimg1
+      attributes:
+        some: crazy-attribute


### PR DESCRIPTION
The intended behavior for old unsupported content types such as
DOCKER is to log a warning and ignore discovered push items.

However, it is likely that the metadata file for the push also
has entries for those files. In that case, these must be able to
pass validation, otherwise we'll get an error rather than a
warning.

To make that work, add a loose schema for those unsupported types.
It does not validate any attributes on the metadata, as the goal
is simply to ignore these entries.