### PR TITLE
staged: fix overly strict erratum pkglist schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `id` field within erratum reference objects may now be provided as an integer
   (it will be converted to a string).
+- The `name` field within erratum pkglist objects is now optional, defaulting to
+  a blank string.
 
 ## [2.0.0] - 2020-11-04
 

--- a/src/pushsource/_impl/model/erratum.py
+++ b/src/pushsource/_impl/model/erratum.py
@@ -129,7 +129,7 @@ class ErratumPackageCollection(object):
     advisories typically contain one collection per module.
     """
 
-    name = attr.ib(type=str, validator=instance_of_str)
+    name = attr.ib(type=str, default="", validator=instance_of_str)
     """A name for this collection. The collection name has no specific meaning,
     but must be unique within an advisory.
     """
@@ -186,8 +186,8 @@ class ErratumPackageCollection(object):
             )
 
         return cls(
-            name=data["name"],
-            short=data["short"],
+            name=data.get("name") or "",
+            short=data.get("short") or "",
             packages=packages,
             module=ErratumModule._from_data(data.get("module")),
         )

--- a/src/pushsource/_impl/schema/errata-schema.yaml
+++ b/src/pushsource/_impl/schema/errata-schema.yaml
@@ -74,8 +74,6 @@ definitions:
                 items:
                     $ref: "#/definitions/pkg"
                 uniqueItems: true
-        required:
-        - name
 
     pkg:
         type: object

--- a/tests/errata/data/RHSA-2020:0509.yaml
+++ b/tests/errata/data/RHSA-2020:0509.yaml
@@ -54,8 +54,7 @@ cdn_metadata:
   id: RHSA-2020:0509
   issued: 2020-02-13 19:00:11 UTC
   pkglist:
-  - name: RHSA-2020:0509
-    packages:
+  - packages:
     - arch: ppc64le
       epoch: '0'
       filename: sudo-1.8.25p1-4.el8_0.3.ppc64le.rpm
@@ -140,7 +139,6 @@ cdn_metadata:
       - sha256
       - 43e318fa49e4df685ea0d5f0925a00a336236b2e20f27f9365c39a48102c2cf6
       version: 1.8.25p1
-    short: ''
   pulp_user_metadata:
     content_types:
     - rpm

--- a/tests/errata/test_errata_rpms.py
+++ b/tests/errata/test_errata_rpms.py
@@ -137,7 +137,7 @@ def test_errata_rpms_via_koji(fake_errata_tool, fake_koji, koji_dir):
     # pkglist should have just one collection
     assert errata_item.pkglist == [
         ErratumPackageCollection(
-            name="RHSA-2020:0509",
+            name="",
             packages=[
                 ErratumPackage(
                     arch="ppc64le",


### PR DESCRIPTION
The schema for the "pkglist" field within errata had set "name"
as a required field.

I have discovered some data in the wild for which that field is
missing, and after reviewing the code of pulp_rpm it seems that
data without this field is in fact able to be uploaded, so the
schema was too strict. Adjust so that 'name' (and 'short') are
both considered optional, with blank defaults.