### PR TITLE
erratum: allow integers for 'id' within references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- The `id` field within erratum reference objects may now be provided as an integer
+  (it will be converted to a string).
 
 ## [2.0.0] - 2020-11-04
 

--- a/src/pushsource/_impl/model/erratum.py
+++ b/src/pushsource/_impl/model/erratum.py
@@ -21,7 +21,7 @@ class ErratumReference(object):
     href = attr.ib(type=str, validator=instance_of_str)
     """A URL."""
 
-    id = attr.ib(type=str, validator=optional_str)
+    id = attr.ib(type=str, converter=int2str, validator=optional_str)
     """A short ID for the reference, unique within this erratum."""
 
     title = attr.ib(type=str, validator=optional_str)

--- a/src/pushsource/_impl/schema/errata-schema.yaml
+++ b/src/pushsource/_impl/schema/errata-schema.yaml
@@ -39,7 +39,13 @@ definitions:
             href:
                 type: string
             id:
-                $ref: "#/definitions/optional_string"
+                # It is preferred to use strings for this field, however
+                # some very old data might use integers (e.g. bugzilla bug ID).
+                # These will be converted to strings on load.
+                type:
+                - integer
+                - string
+                - "null"
             title:
                 $ref: "#/definitions/optional_string"
             type:

--- a/tests/errata/data/RHBA-2020:0518.yaml
+++ b/tests/errata/data/RHBA-2020:0518.yaml
@@ -41,7 +41,7 @@ cdn_metadata:
       of Marvell WiFi driver'
     type: bugzilla
   - href: https://bugzilla.redhat.com/show_bug.cgi?id=1771909
-    id: '1771909'
+    id: 1771909
     title: 'CVE-2019-17133 kernel: buffer overflow in cfg80211_mgd_wext_giwessid in
       net/wireless/wext-sme.c'
     type: bugzilla
@@ -55,7 +55,7 @@ cdn_metadata:
       and core dumping in CVE-2019-11599'
     type: bugzilla
   - href: https://bugzilla.redhat.com/show_bug.cgi?id=1774870
-    id: '1774870'
+    id: 1774870
     title: 'CVE-2019-14895 kernel: heap-based buffer overflow in mwifiex_process_country_ie()
       function in drivers/net/wireless/marvell/mwifiex/sta_ioctl.c'
     type: bugzilla

--- a/tests/errata/data/RHSA-2020:0509.yaml
+++ b/tests/errata/data/RHSA-2020:0509.yaml
@@ -148,7 +148,7 @@ cdn_metadata:
   reboot_suggested: false
   references:
   - href: https://access.redhat.com/errata/RHSA-2020:0509
-    id: RHSA-2020:0509
+    id: null
     title: RHSA-2020:0509
     type: self
   - href: https://bugzilla.redhat.com/show_bug.cgi?id=1796944


### PR DESCRIPTION
This field was declared as a string (or null) and is always stored
as such.

In practice, because Bugzilla uses integers for bug IDs, some older
data exists which had used integers rather than strings. Let's
tolerate such data as well - it's converted to string on load.