### PR TITLE
Fix too strict handling of 'description'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+
+- Fix too strict schema on staging metadata for FILES: "description" field is permitted
+  to be an empty string.
 
 ## [2.2.0] - 2020-11-19
 

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -112,7 +112,6 @@ definitions:
                 # Human-readable brief description of the file, e.g.
                 # appropriate for use in a file browsing UI
                 type: string
-                minLength: 1
 
         required:
         - description

--- a/tests/staged/data/simple_files/staged.yaml
+++ b/tests/staged/data/simple_files/staged.yaml
@@ -15,6 +15,9 @@ payload:
       relative_path: dest2/FILES/some-file
       sha256sum: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
       version: 1.2.3
+      attributes:
+        # empty description is odd, but accepted
+        description: ""
 
     # a file with some attributes
     - filename: some-iso

--- a/tests/staged/test_staged_simple_files.py
+++ b/tests/staged/test_staged_simple_files.py
@@ -38,7 +38,7 @@ def test_staged_simple_files():
             origin=staged_dir,
             build=None,
             signing_key=None,
-            description=None,
+            description="",
             version="1.2.3",
         ),
         FilePushItem(


### PR DESCRIPTION
This field in schema had been declared to have a minimum length of
at least one character (i.e. not an empty string), since it seems
that the description may as well be omitted if you're going to pass
an empty string.

However, in practice it seems that empty strings have genuinely
been used in the past here and files with empty descriptions (rather
than absent) do exist in the wild. It was not intended for the
schema to block any existing workflows, so let's loosen it up and
make it accept this data.