### PR TITLE
Fix missing reboot_suggested field from erratum pkglists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Fixed
+
+- Fix missing `reboot_suggested` field in erratum pkglist schema and model.
+  The field was formerly permitted in the top-level erratum schema only, which was
+  incorrect.
 
 ## [2.3.0] - 2020-11-23
 

--- a/src/pushsource/_impl/model/erratum.py
+++ b/src/pushsource/_impl/model/erratum.py
@@ -112,6 +112,9 @@ class ErratumPackage(object):
     :meth:`filename` for the source RPM itself.
     """
 
+    reboot_suggested = attr.ib(type=bool, default=False, validator=instance_of(bool))
+    """True if rebooting host machine is recommended after installing this package."""
+
     md5sum = attr.ib(type=str, default=None, converter=md5str)
     """MD5 checksum of this RPM in hex string form, if available."""
 
@@ -180,6 +183,7 @@ class ErratumPackageCollection(object):
                     version=raw_pkg["version"],
                     release=raw_pkg["release"],
                     src=raw_pkg["src"],
+                    reboot_suggested=raw_pkg.get("reboot_suggested") or False,
                     md5sum=sums.get("md5"),
                     sha1sum=sums.get("sha1"),
                     sha256sum=sums.get("sha256"),
@@ -220,7 +224,14 @@ class ErratumPushItem(PushItem):
     """Number of times advisory has been revised and published (starting at '1')."""
 
     reboot_suggested = attr.ib(type=bool, default=False, validator=instance_of(bool))
-    """True if rebooting host machine is recommended after installing this advisory."""
+    """True if rebooting host machine is recommended after installing this advisory.
+
+    .. warning::
+        The intended usage of this field is unclear.
+
+        In practice, tools such as yum are instead consuming the ``reboot_suggested`` field
+        from :class:`ErratumPackage`.
+    """
 
     references = attr.ib(
         type=list, default=attr.Factory(frozenlist), converter=frozenlist

--- a/src/pushsource/_impl/schema/errata-schema.yaml
+++ b/src/pushsource/_impl/schema/errata-schema.yaml
@@ -92,6 +92,9 @@ definitions:
                 type: string
             version:
                 type: string
+            # Note: this is also present at the top level of the erratum.
+            reboot_suggested:
+                type: boolean
             sum:
                 type: array
                 items:
@@ -119,6 +122,7 @@ properties:
         type: string
     pushcount:
         $ref: "#/definitions/intstr"
+    # Note: this is also present under each package (if there are any).
     reboot_suggested:
         type: boolean
     release:

--- a/tests/errata/data/RHSA-2020:0509.yaml
+++ b/tests/errata/data/RHSA-2020:0509.yaml
@@ -121,6 +121,7 @@ cdn_metadata:
       name: sudo-debugsource
       release: 4.el8_0.3
       src: sudo-1.8.25p1-4.el8_0.3.src.rpm
+      reboot_suggested: true
       sum:
       - md5
       - d6da7e2e3d9efe050fef2e8d047682be

--- a/tests/errata/test_errata_rpms.py
+++ b/tests/errata/test_errata_rpms.py
@@ -207,6 +207,7 @@ def test_errata_rpms_via_koji(fake_errata_tool, fake_koji, koji_dir):
                     version="1.8.25p1",
                     release="4.el8_0.3",
                     src="sudo-1.8.25p1-4.el8_0.3.src.rpm",
+                    reboot_suggested=True,
                     md5sum="d6da7e2e3d9efe050fef2e8d047682be",
                     sha1sum=None,
                     sha256sum="355cbb9dc348b17782cff57120391685d6a1f6884facc54fac4b7fb54abeffba",

--- a/tests/staged/data/simple_errata/dest1/ERRATA/advisory2.json
+++ b/tests/staged/data/simple_errata/dest1/ERRATA/advisory2.json
@@ -86,6 +86,7 @@
           "epoch": "0",
           "arch": "ppc64le",
           "filename": "sudo-debuginfo-1.8.25p1-4.el8_0.3.ppc64le.rpm",
+          "reboot_suggested": false,
           "sum": [
             "md5",
             "e242826fb38f487502cdc1f1a06991d2",
@@ -116,6 +117,7 @@
           "epoch": "0",
           "arch": "ppc64le",
           "filename": "sudo-debugsource-1.8.25p1-4.el8_0.3.ppc64le.rpm",
+          "reboot_suggested": true,
           "sum": [
             "md5",
             "d6da7e2e3d9efe050fef2e8d047682be",

--- a/tests/staged/test_staged_simple_errata.py
+++ b/tests/staged/test_staged_simple_errata.py
@@ -249,6 +249,7 @@ def test_staged_simple_errata():
                             version="1.8.25p1",
                             release="4.el8_0.3",
                             src="sudo-1.8.25p1-4.el8_0.3.src.rpm",
+                            reboot_suggested=True,
                             md5sum="d6da7e2e3d9efe050fef2e8d047682be",
                             sha1sum=None,
                             sha256sum="355cbb9dc348b17782cff57120391685d6a1f6884facc54fac4b7fb54abeffba",


### PR DESCRIPTION
The reboot_suggested field is unusual in that it can appear
at two levels within an erratum: once at the top level, but also
within each entry under 'pkglist'.

The latter previously was incorrectly missing from the schemas and
model in this library, leading to a crash if an attempt was made
to push an erratum using the field in pkglist. This is important
because it's actually the field in pkglist which is consumed by
yum (and the usage of the other field is unclear - it's possible
it only exists for historical reasons).

Let's update the model and schema to accept reboot_suggested in
pkglist, update a few tests to ensure that this is covered, and
also add a warning about the quirkiness of this field to the docs.