### PR TITLE
Add billing codes to staged AMI push item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+
+- Added optional field `billing_codes` to the AMI staged push item schema and model.
 
 ## [2.4.0] - 2020-12-11
 

--- a/src/pushsource/__init__.py
+++ b/src/pushsource/__init__.py
@@ -8,7 +8,7 @@ from pushsource._impl.model import (
     RpmPushItem,
     AmiPushItem,
     AmiRelease,
-    AmiBillingCode,
+    AmiBillingCodes,
     ErratumPushItem,
     ErratumReference,
     ErratumModule,

--- a/src/pushsource/__init__.py
+++ b/src/pushsource/__init__.py
@@ -8,6 +8,7 @@ from pushsource._impl.model import (
     RpmPushItem,
     AmiPushItem,
     AmiRelease,
+    AmiBillingCode,
     ErratumPushItem,
     ErratumReference,
     ErratumModule,

--- a/src/pushsource/_impl/backend/staged/staged_ami.py
+++ b/src/pushsource/_impl/backend/staged/staged_ami.py
@@ -1,7 +1,7 @@
 import os
 import logging
 
-from ...model import AmiRelease, AmiPushItem
+from ...model import AmiRelease, AmiPushItem, AmiBillingCode
 from .staged_base import StagedBaseMixin, handles_type
 
 LOG = logging.getLogger("pushsource")
@@ -33,6 +33,17 @@ class StagedAmiMixin(StagedBaseMixin):
 
         release = AmiRelease(**release_kwargs)
 
+        billing_code_md = attributes.get("billing_code")
+
+        billing_code_attrs = ["name", "code"]
+        billing_code_kwargs = {}
+
+        for key in billing_code_attrs:
+            if key in billing_code_md:
+                billing_code_kwargs[key] = billing_code_md[key]
+
+        billing_code = AmiBillingCode(**billing_code_kwargs)
+
         image_attrs = [
             "type",
             "region",
@@ -43,7 +54,7 @@ class StagedAmiMixin(StagedBaseMixin):
             "sriov_net_support",
             "ena_support",
         ]
-        image_kwargs = {"release": release}
+        image_kwargs = {"release": release, "billing_code": billing_code}
         for key in image_attrs:
             if key in attributes:
                 image_kwargs[key] = attributes[key]

--- a/src/pushsource/_impl/backend/staged/staged_ami.py
+++ b/src/pushsource/_impl/backend/staged/staged_ami.py
@@ -1,7 +1,7 @@
 import os
 import logging
 
-from ...model import AmiRelease, AmiPushItem, AmiBillingCode
+from ...model import AmiRelease, AmiPushItem, AmiBillingCodes
 from .staged_base import StagedBaseMixin, handles_type
 
 LOG = logging.getLogger("pushsource")
@@ -33,16 +33,19 @@ class StagedAmiMixin(StagedBaseMixin):
 
         release = AmiRelease(**release_kwargs)
 
-        billing_code_md = attributes.get("billing_code")
+        image_kwargs = {"release": release}
 
-        billing_code_attrs = ["name", "code"]
-        billing_code_kwargs = {}
+        billing_codes_md = attributes.get("billing_codes") or {}
+        if billing_codes_md:
+            billing_codes_attrs = ["name", "codes"]
+            billing_codes_kwargs = {}
 
-        for key in billing_code_attrs:
-            if key in billing_code_md:
-                billing_code_kwargs[key] = billing_code_md[key]
+            for key in billing_codes_attrs:
+                if key in billing_codes_md:
+                    billing_codes_kwargs[key] = billing_codes_md[key]
 
-        billing_code = AmiBillingCode(**billing_code_kwargs)
+            billing_codes = AmiBillingCodes(**billing_codes_kwargs)
+            image_kwargs.update({"billing_codes": billing_codes})
 
         image_attrs = [
             "type",
@@ -54,7 +57,7 @@ class StagedAmiMixin(StagedBaseMixin):
             "sriov_net_support",
             "ena_support",
         ]
-        image_kwargs = {"release": release, "billing_code": billing_code}
+
         for key in image_attrs:
             if key in attributes:
                 image_kwargs[key] = attributes[key]

--- a/src/pushsource/_impl/model/__init__.py
+++ b/src/pushsource/_impl/model/__init__.py
@@ -11,4 +11,4 @@ from .file import FilePushItem
 from .modulemd import ModuleMdPushItem
 from .comps import CompsXmlPushItem
 from .productid import ProductIdPushItem
-from .ami import AmiPushItem, AmiRelease, AmiBillingCode
+from .ami import AmiPushItem, AmiRelease, AmiBillingCodes

--- a/src/pushsource/_impl/model/__init__.py
+++ b/src/pushsource/_impl/model/__init__.py
@@ -11,4 +11,4 @@ from .file import FilePushItem
 from .modulemd import ModuleMdPushItem
 from .comps import CompsXmlPushItem
 from .productid import ProductIdPushItem
-from .ami import AmiPushItem, AmiRelease
+from .ami import AmiPushItem, AmiRelease, AmiBillingCode

--- a/src/pushsource/_impl/model/ami.py
+++ b/src/pushsource/_impl/model/ami.py
@@ -42,14 +42,14 @@ class AmiRelease(object):
 
 
 @attr.s()
-class AmiBillingCode(object):
-    """Billing code associated with an AMI."""
+class AmiBillingCodes(object):
+    """Billing codes associated with an AMI."""
 
     name = attr.ib(type=str, default=None, validator=instance_of_str)
-    """Billing code name, for example: Hourly2"""
+    """Billing codes name, for example: Hourly2, arbitrary string for making image name unique"""
 
-    code = attr.ib(type=str, default=None, validator=instance_of_str)
-    """Code of given billing code, for example: bp-1234abcd"""
+    codes = attr.ib(type=list, default=None, validator=optional(instance_of(list)))
+    """List of billing codes, for example: ['bp-1234abcd', 'bp-5678efgh']"""
 
 
 @attr.s()
@@ -94,7 +94,9 @@ class AmiPushItem(PushItem):
         type=bool, default=None, validator=optional(instance_of(bool))
     )
     """``True`` if the image supports Elastic Network Adapter (ENA)."""
-    billing_code = attr.ib(
-        type=AmiBillingCode, default=None, validator=instance_of(AmiBillingCode)
+    billing_codes = attr.ib(
+        type=AmiBillingCodes,
+        default=None,
+        validator=optional(instance_of(AmiBillingCodes)),
     )
-    """Billing code (:class`AmiBillingCode`) associated with this image."""
+    """Billing codes (:class`AmiBillingCodes`) associated with this image."""

--- a/src/pushsource/_impl/model/ami.py
+++ b/src/pushsource/_impl/model/ami.py
@@ -42,6 +42,17 @@ class AmiRelease(object):
 
 
 @attr.s()
+class AmiBillingCode(object):
+    """Billing code associated with an AMI."""
+
+    name = attr.ib(type=str, default=None, validator=instance_of_str)
+    """Billing code name, for example: Hourly2"""
+
+    code = attr.ib(type=str, default=None, validator=instance_of_str)
+    """Code of given billing code, for example: bp-1234abcd"""
+
+
+@attr.s()
 class AmiPushItem(PushItem):
     """A :class:`~pushsource.PushItem` representing an Amazon Machine Image (or "AMI").
 
@@ -83,3 +94,7 @@ class AmiPushItem(PushItem):
         type=bool, default=None, validator=optional(instance_of(bool))
     )
     """``True`` if the image supports Elastic Network Adapter (ENA)."""
+    billing_code = attr.ib(
+        type=AmiBillingCode, default=None, validator=instance_of(AmiBillingCode)
+    )
+    """Billing code (:class`AmiBillingCode`) associated with this image."""

--- a/src/pushsource/_impl/model/ami.py
+++ b/src/pushsource/_impl/model/ami.py
@@ -1,5 +1,7 @@
 import datetime
 
+from frozenlist2 import frozenlist
+
 from .base import PushItem
 from .. import compat_attr as attr
 from .conv import datestr, instance_of_str, instance_of, optional_str, optional
@@ -46,10 +48,10 @@ class AmiBillingCodes(object):
     """Billing codes associated with an AMI."""
 
     name = attr.ib(type=str, default=None, validator=instance_of_str)
-    """Billing codes name, for example: Hourly2, arbitrary string for making image name unique"""
+    """Billing codes name, for example: Hourly2, arbitrary string for making image name unique."""
 
-    codes = attr.ib(type=list, default=None, validator=optional(instance_of(list)))
-    """List of billing codes, for example: ['bp-1234abcd', 'bp-5678efgh']"""
+    codes = attr.ib(type=list, default=attr.Factory(frozenlist), converter=frozenlist)
+    """List of billing codes, for example: ['bp-1234abcd', 'bp-5678efgh']."""
 
 
 @attr.s()

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -94,6 +94,10 @@ definitions:
                 - boolean
                 - "null"
 
+            billing_code:
+                $ref: "#/definitions/ami_billing_code"
+
+
         required:
         - release
         - region
@@ -211,6 +215,19 @@ definitions:
         - string
         - "null"
         minLength: 1
+
+    ami_billing_code:
+        # Billing code for an AMI
+        type:
+        - object
+        properties:
+            name:
+                type: string
+            code:
+                type: string
+        required:
+        - name
+        - code
 
 ###############################################################################
 #  Main schema

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -94,8 +94,8 @@ definitions:
                 - boolean
                 - "null"
 
-            billing_code:
-                $ref: "#/definitions/ami_billing_code"
+            billing_codes:
+                $ref: "#/definitions/ami_billing_codes"
 
 
         required:
@@ -216,18 +216,19 @@ definitions:
         - "null"
         minLength: 1
 
-    ami_billing_code:
-        # Billing code for an AMI
+    ami_billing_codes:
+        # Billing codes for an AMI
         type:
         - object
+        - "null"
         properties:
             name:
                 type: string
-            code:
-                type: string
+            codes:
+                type: array
         required:
         - name
-        - code
+        - codes
 
 ###############################################################################
 #  Main schema

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -226,6 +226,8 @@ definitions:
                 type: string
             codes:
                 type: array
+                items:
+                    type: string
         required:
         - name
         - codes

--- a/tests/staged/data/simple_ami/staged.yaml
+++ b/tests/staged/data/simple_ami/staged.yaml
@@ -23,3 +23,7 @@ payload:
       type: access
       virtualization: hvm
       volume: gp2
+      billing_code:
+        name: FakeBcName
+        code: fake-bc-code
+

--- a/tests/staged/data/simple_ami_with_bc/staged.yaml
+++ b/tests/staged/data/simple_ami_with_bc/staged.yaml
@@ -23,3 +23,9 @@ payload:
       type: access
       virtualization: hvm
       volume: gp2
+      billing_codes:
+        name: FakeBcName
+        codes:
+          - bp-1234
+          - bp-abcd
+

--- a/tests/staged/test_staged_simple_ami.py
+++ b/tests/staged/test_staged_simple_ami.py
@@ -1,6 +1,6 @@
 import os
 
-from pushsource import Source, AmiPushItem, AmiRelease
+from pushsource import Source, AmiPushItem, AmiRelease, AmiBillingCode
 
 
 DATADIR = os.path.join(os.path.dirname(__file__), "data")
@@ -11,7 +11,6 @@ def test_staged_simple_ami():
     source = Source.get("staged:" + staged_dir)
 
     files = list(source)
-
     # It should load all the expected files with fields filled in by metadata
     assert files == [
         AmiPushItem(
@@ -43,5 +42,6 @@ def test_staged_simple_ami():
             description="A sample image for testing",
             sriov_net_support="simple",
             ena_support=True,
+            billing_code=AmiBillingCode(name="FakeBcName", code="fake-bc-code"),
         )
     ]

--- a/tests/staged/test_staged_simple_ami.py
+++ b/tests/staged/test_staged_simple_ami.py
@@ -1,6 +1,6 @@
 import os
 
-from pushsource import Source, AmiPushItem, AmiRelease, AmiBillingCode
+from pushsource import Source, AmiPushItem, AmiRelease, AmiBillingCodes
 
 
 DATADIR = os.path.join(os.path.dirname(__file__), "data")
@@ -42,6 +42,48 @@ def test_staged_simple_ami():
             description="A sample image for testing",
             sriov_net_support="simple",
             ena_support=True,
-            billing_code=AmiBillingCode(name="FakeBcName", code="fake-bc-code"),
+        )
+    ]
+
+
+def test_staged_simple_ami_with_bc():
+    staged_dir = os.path.join(DATADIR, "simple_ami_with_bc")
+    source = Source.get("staged:" + staged_dir)
+
+    files = list(source)
+    # It should load all the expected files with fields filled in by metadata
+    assert files == [
+        AmiPushItem(
+            name="fake-image.raw",
+            state="PENDING",
+            src=os.path.join(staged_dir, "dest1/AWS_IMAGES/fake-image.raw"),
+            dest=["dest1"],
+            md5sum=None,
+            sha256sum=None,
+            origin=staged_dir,
+            build=None,
+            signing_key=None,
+            release=AmiRelease(
+                product="Fake-Product",
+                date="20200511",
+                arch="x86_64",
+                respin=1,
+                version="Fake-Version",
+                base_product=None,
+                base_version=None,
+                variant="Fake-Variant",
+                type="ga",
+            ),
+            type="access",
+            region="cn-north-1",
+            virtualization="hvm",
+            volume="gp2",
+            root_device="/dev/sda1",
+            description="A sample image for testing",
+            sriov_net_support="simple",
+            ena_support=True,
+            billing_codes=AmiBillingCodes(
+                name="FakeBcName", codes=["bp-1234", "bp-abcd"]
+            ),
         )
     ]


### PR DESCRIPTION
This commit adds billing codes field for AMI staged push item schema
and model.

This field is optional and it's a dict consisting of
- "name", that is arbitrary string used for compiling unique AMI image name 
- "codes" list of actual billing codes that should be for AMI registering.