### PR TITLE
Fix argument leaks in get_partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix keyword arguments leaking between subsequent calls to a source prepared using
+  `Source.get_partial`.
+
 ## [2.5.0] - 2021-03-02
 
 ### Added

--- a/src/pushsource/_impl/source.py
+++ b/src/pushsource/_impl/source.py
@@ -156,8 +156,9 @@ class Source(object):
 
         @functools.wraps(klass)
         def partial_source(*inner_args, **inner_kwargs):
-            url_kwargs.update(inner_kwargs)
-            return klass(*inner_args, **url_kwargs)
+            kwargs = url_kwargs.copy()
+            kwargs.update(inner_kwargs)
+            return klass(*inner_args, **kwargs)
 
         return partial_source
 


### PR DESCRIPTION
Previously if you've prepared a source like this:

```python
src = Source.get_partial('somebackend', ...)
inst1 = src(key1='value1')
inst2 = src(key2='value2')
```

...then the second call would be passed both key1 and key2
incorrectly.

This happened due to some code which intended to merge two
dicts together, but it did this via an in-place update of
a dict used at every call rather than making a copy.
Fix it to do the merge safely.

I don't think this affects any current usage of the library,
but it would interfere with errata source being prepared in
RHELDST-5430.