### PR TITLE
Add a reset() feature to remove all custom backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `Source.reset` to restore default state of library, intended
+  for testing.
+
 ### Fixed
 
 - Fix keyword arguments leaking between subsequent calls to a source prepared using

--- a/src/pushsource/_impl/backend/errata_source.py
+++ b/src/pushsource/_impl/backend/errata_source.py
@@ -248,4 +248,4 @@ class ErrataSource(Source):
                 yield pushitem
 
 
-Source.register_backend("errata", ErrataSource)
+Source._register_backend_builtin("errata", ErrataSource)

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -386,4 +386,4 @@ class KojiSource(Source):
                 yield pushitem
 
 
-Source.register_backend("koji", KojiSource)
+Source._register_backend_builtin("koji", KojiSource)

--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -162,4 +162,4 @@ class StagedSource(
                 yield pushitem
 
 
-Source.register_backend("staged", StagedSource)
+Source._register_backend_builtin("staged", StagedSource)

--- a/src/pushsource/_impl/source.py
+++ b/src/pushsource/_impl/source.py
@@ -34,6 +34,7 @@ class Source(object):
     """
 
     _BACKENDS = {}
+    _BACKENDS_BUILTIN = {}
 
     def __iter__(self):
         """Iterate over the push items contained within this source.
@@ -191,3 +192,24 @@ class Source(object):
             raise TypeError("expected callable, got: %s" % repr(factory))
 
         cls._BACKENDS[name] = factory
+
+    @classmethod
+    def _register_backend_builtin(cls, name, factory):
+        # Private equivalent of register_backend which also flags the
+        # backend as built-in, i.e. it will be restored on a call to reset.
+        cls.register_backend(name, factory)
+        cls._BACKENDS_BUILTIN[name] = factory
+
+    @classmethod
+    def reset(cls):
+        """Reset the library to the default configuration.
+
+        This method will undo the effect of any prior calls to
+        :meth:`~pushsource.Source.register_backend`, restoring only the
+        default backends provided by the pushsource library.
+
+        This may be used from within tests to ensure a known state.
+
+        .. versionadded:: 2.6.0
+        """
+        cls._BACKENDS = cls._BACKENDS_BUILTIN.copy()

--- a/tests/source/test_source_reset.py
+++ b/tests/source/test_source_reset.py
@@ -1,0 +1,56 @@
+from pytest import raises
+
+from pushsource import Source, SourceUrlError
+
+
+def test_reset_removes_custom_backend():
+    """reset removes a custom registered backend."""
+
+    source_instance = object()
+
+    def source_factory(*args, **kwargs):
+        return source_instance
+
+    Source.register_backend("mytest", source_factory)
+
+    # I can get an instance of it now
+    assert Source.get("mytest:") is source_instance
+
+    # But if I reset...
+    Source.reset()
+
+    # Then I can't get it any more
+    with raises(SourceUrlError) as exc_info:
+        Source.get("mytest:")
+
+    assert "no registered backend 'mytest'" in str(exc_info)
+
+
+def test_reset_restores_overridden_backend():
+    """reset restores the original backend for anything which has been
+    overridden."""
+
+    # I can get an instance of a built-in backend, like 'staged'.
+    # Note: doesn't matter that we're pointing at nonexistent directory
+    # (reading doesn't happen until we iterate)
+    Source.get("staged:/notexist")
+
+    source_instance = object()
+
+    def source_factory(*args, **kwargs):
+        return source_instance
+
+    # Can override the built-in 'staged' backend.
+    Source.register_backend("staged", source_factory)
+
+    # Now it will use what I registered
+    assert Source.get("staged:/notexist") is source_instance
+
+    # But if I reset...
+    Source.reset()
+
+    # Then I'm not getting what I registered any more, but I'm
+    # still getting something OK
+    new_src = Source.get("staged:/notexist")
+    assert new_src
+    assert new_src is not source_instance


### PR DESCRIPTION
When a user of this library needs to customize backends, as is the
case in Pub, writing tests for that code can be cumbersome as the
tests would have to carefully undo any customizations made to ensure
that custom backends aren't left behind interfering with later tests.

Let's add a reset method so we can simply do "Source.reset()" during
test cleanup, to put everything back to the original state.

Refactoring connected with RHELDST-5431.