### PR TITLE
docs: clean up docs for constructors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,7 @@ html_sidebars = {
 
 
 # -- Extension configuration -------------------------------------------------
-autoclass_content = "both"
+autoclass_content = "class"
 autodoc_member_order = "bysource"
 autodoc_inherit_docstrings = False
 intersphinx_mapping = {

--- a/docs/sources/errata.rst
+++ b/docs/sources/errata.rst
@@ -66,3 +66,4 @@ Python API reference
 
 .. autoclass:: pushsource.ErrataSource
    :members:
+   :special-members: __init__

--- a/docs/sources/koji.rst
+++ b/docs/sources/koji.rst
@@ -84,3 +84,4 @@ Python API reference
 
 .. autoclass:: pushsource.KojiSource
    :members:
+   :special-members: __init__

--- a/docs/sources/staged.rst
+++ b/docs/sources/staged.rst
@@ -191,3 +191,4 @@ Python API reference
 
 .. autoclass:: pushsource.StagedSource
    :members:
+   :special-members: __init__


### PR DESCRIPTION
autoclass_content="both" means that we always render docstrings
of \_\_init\_\_. Unfortunately, for attrs-generated classes such as
all the PushItem implementations, the \_\_init\_\_ doc string is always
"Method generated by attrs for class \<foo\>" which seems ugly and
confusing.

Let's suppress that, and just use the class-level doc string instead
by default. Classes where \_\_init\_\_ needs documenting can explicitly
enable it.