### PR TITLE
docs: fix missing doc for Source.__iter__

### DIFF
--- a/docs/sources/base.rst
+++ b/docs/sources/base.rst
@@ -6,5 +6,6 @@ The ``Source`` class is the base from which all pushsource backends derive.
 
 .. autoclass:: pushsource.Source
    :members:
+   :special-members: __iter__
 
 .. autoclass:: pushsource.SourceUrlError


### PR DESCRIPTION
Special methods (\_\_foo\_\_) are not included in docs by default,
even if they have doc strings.

It makes sense to include this one, since the whole point of a
Source instance is to be iterated over. The purpose of the class
may be rather unclear if this can't be seen.