### PR TITLE
docs: improve type info for attrs-generated classes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,9 @@ import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
+# bundled extensions
+sys.path.append(os.path.abspath("ext"))
+
 
 # -- Project information -----------------------------------------------------
 
@@ -45,6 +48,8 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.githubpages",
     "sphinx.ext.viewcode",
+    # own extensions in 'ext' dir
+    "attr_types",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/ext/attr_types.py
+++ b/docs/ext/attr_types.py
@@ -1,0 +1,52 @@
+import sys
+
+import attr
+
+
+def add_attr_types(app, what, name, obj, options, lines):
+    # If we are generating docs for an attr.ib-defined attribute
+    # where 'type' has been set, append this type info to the
+    # doc string in the format understood by sphinx.
+
+    if what != "attribute":
+        # not an attribute => nothing to do
+        return
+
+    if ":type:" in "".join(lines):
+        # type has already been documented explicitly, don't
+        # try to override it
+        return
+
+    components = name.split(".")
+    if len(components) != 3 or components[0] != "pushsource":
+        # We are looking specifically for public fields of the form:
+        # pushsource.<class_name>.<attr_name>
+        # For any other cases we'll do nothing.
+        return
+
+    (klass_name, field_name) = components[1:]
+    klass = getattr(sys.modules["pushsource"], klass_name)
+
+    if not attr.has(klass):
+        # not an attrs-using class, nothing to do
+        return
+
+    field = attr.fields_dict(klass).get(field_name)
+    if not field:
+        # not an attr.ib
+        return
+
+    type = field.type
+    if not type:
+        # no type hint declared, can't do anything
+        return
+
+    # phew, after all the above we know we're documenting an attrs-based
+    # field and we know exactly what type it is, so add it to the end of
+    # the doc string.
+    lines.extend(["", ":type: %s" % type.__name__])
+
+
+def setup(app):
+    # entrypoint invoked by sphinx when extension is loaded
+    app.connect("autodoc-process-docstring", add_attr_types)

--- a/src/pushsource/_impl/model/ami.py
+++ b/src/pushsource/_impl/model/ami.py
@@ -51,7 +51,10 @@ class AmiBillingCodes(object):
     """Billing codes name, for example Hourly2, arbitrary string for making image name unique."""
 
     codes = attr.ib(type=list, default=attr.Factory(frozenlist), converter=frozenlist)
-    """List of billing codes, for example ['bp-1234abcd', 'bp-5678efgh']."""
+    """List of billing codes, for example ['bp-1234abcd', 'bp-5678efgh'].
+
+    :type: list[str]
+    """
 
 
 @attr.s()
@@ -69,7 +72,7 @@ class AmiPushItem(PushItem):
     release = attr.ib(
         type=AmiRelease, default=None, validator=optional(instance_of(AmiRelease))
     )
-    """Release metadata (:class:`AmiRelease`) associated with this image."""
+    """Release metadata associated with this image."""
 
     type = attr.ib(type=str, default=None, validator=optional_str)
     """Billing type associated with the image, e.g. "hourly" or "access"."""
@@ -101,4 +104,4 @@ class AmiPushItem(PushItem):
         default=None,
         validator=optional(instance_of(AmiBillingCodes)),
     )
-    """Billing codes (:class:`AmiBillingCodes`) associated with this image."""
+    """Billing codes associated with this image."""

--- a/src/pushsource/_impl/model/base.py
+++ b/src/pushsource/_impl/model/base.py
@@ -58,6 +58,8 @@ class PushItem(object):
 
     * a path to a directory (for items pushed using rsync)
     * a Pulp repository name (for items pushed using Pulp)
+
+    :type: list[str]
     """
 
     md5sum = attr.ib(type=str, default=None, converter=md5str)

--- a/src/pushsource/_impl/model/erratum.py
+++ b/src/pushsource/_impl/model/erratum.py
@@ -141,7 +141,10 @@ class ErratumPackageCollection(object):
     packages = attr.ib(
         type=list, default=attr.Factory(frozenlist), converter=frozenlist
     )
-    """List of packages (:class:`ErratumPackage`) within this collection."""
+    """List of packages within this collection.
+
+    :type: list[ErratumPackage]
+    """
 
     short = attr.ib(type=str, default="", validator=instance_of_str)
     """An alternative name for this collection. In practice, this field
@@ -236,11 +239,16 @@ class ErratumPushItem(PushItem):
     references = attr.ib(
         type=list, default=attr.Factory(frozenlist), converter=frozenlist
     )
-    """A list of references (:class:`ErratumReference`) associated with the advisory."""
+    """A list of references associated with the advisory.
+
+    :type: list[ErratumReference]
+    """
 
     pkglist = attr.ib(type=list, default=attr.Factory(frozenlist), converter=frozenlist)
-    """A list of package collections (:class:`ErratumPackageCollection`)
-    associated with the advisory."""
+    """A list of package collections associated with the advisory.
+
+    :type: list[ErratumPackageCollection]
+    """
 
     from_ = attr.ib(type=str, default=None, validator=optional_str)
     """Contact email address for the owner of the advisory.
@@ -248,6 +256,8 @@ class ErratumPushItem(PushItem):
     Note that the canonical name for this attribute is ``from``. As this clashes
     with a Python keyword, in most contexts the attribute is also available as an
     alias, ``from_``. Where possible, the canonical name ``from`` should be preferred.
+
+    :type: str
     """
 
     rights = attr.ib(type=str, default=None, validator=optional_str)
@@ -294,6 +304,8 @@ class ErratumPushItem(PushItem):
 
     For example, "docker" may be found in this list if the advisory deals
     with container images.
+
+    :type: list[str]
     """
 
     def __str__(self):


### PR DESCRIPTION
It is irritating that we've been defining type metadata for
attributes using attrs library, yet this info hasn't made it into
docs.

As I understand it, once we can drop python2 support, we could use
python3 native type hints and type info would make it into docs
automatically. Until then, turns out it's fairly simple to extend
sphinx to pull out that metadata ourselves, so let's do that.
This means an attribute declared as attr.ib(type=foo, ...) will
appear with "Type: foo" in the generated docs.

It works automatically for almost everything, but a few doc strings
were also tweaked to work better:

- in some cases, a type name previously embedded in doc strings was
  removed because it would now be redundant.

- in other cases, mainly list types, the type is written out
  explicitly because attr.ib only knows we are using a list, and
  doesn't know the type of values within that list.