### PR TITLE
refactor: deduplicate fixtures in errata tests

### DIFF
--- a/tests/errata/conftest.py
+++ b/tests/errata/conftest.py
@@ -1,0 +1,26 @@
+from pytest import fixture
+from mock import patch
+
+from .fake_errata_tool import FakeErrataToolController
+from ..koji.fake_koji import FakeKojiController
+
+
+@fixture
+def fake_errata_tool():
+    controller = FakeErrataToolController()
+    with patch("pushsource._impl.backend.errata_source.ServerProxy") as mock_proxy:
+        mock_proxy.side_effect = controller.proxy
+        yield controller
+
+
+@fixture
+def fake_koji():
+    controller = FakeKojiController()
+    with patch("koji.ClientSession") as mock_session:
+        mock_session.side_effect = controller.session
+        yield controller
+
+
+@fixture
+def koji_dir(tmpdir):
+    yield str(tmpdir.mkdir("koji"))

--- a/tests/errata/test_errata_errors.py
+++ b/tests/errata/test_errata_errors.py
@@ -1,17 +1,6 @@
-from pytest import raises, fixture
-from mock import patch
-
-from .fake_errata_tool import FakeErrataToolController
+from pytest import raises
 
 from pushsource import Source, ErratumPushItem, ErratumReference, RpmPushItem
-
-
-@fixture
-def fake_errata_tool():
-    controller = FakeErrataToolController()
-    with patch("pushsource._impl.backend.errata_source.ServerProxy") as mock_proxy:
-        mock_proxy.side_effect = controller.proxy
-        yield controller
 
 
 def test_errata_files_needs_koji_url(fake_errata_tool):

--- a/tests/errata/test_errata_metadata.py
+++ b/tests/errata/test_errata_metadata.py
@@ -1,17 +1,4 @@
-from pytest import raises, fixture
-from mock import patch
-
-from .fake_errata_tool import FakeErrataToolController
-
 from pushsource import Source, ErratumPushItem, ErratumReference
-
-
-@fixture
-def fake_errata_tool():
-    controller = FakeErrataToolController()
-    with patch("pushsource._impl.backend.errata_source.ServerProxy") as mock_proxy:
-        mock_proxy.side_effect = controller.proxy
-        yield controller
 
 
 def test_errata_typical_metadata(fake_errata_tool):

--- a/tests/errata/test_errata_modules.py
+++ b/tests/errata/test_errata_modules.py
@@ -1,9 +1,4 @@
 import os
-from pytest import raises, fixture
-from mock import patch
-
-from .fake_errata_tool import FakeErrataToolController
-from ..koji.fake_koji import FakeKojiController
 
 from pushsource import (
     Source,
@@ -14,27 +9,6 @@ from pushsource import (
     RpmPushItem,
     ModuleMdPushItem,
 )
-
-
-@fixture
-def fake_errata_tool():
-    controller = FakeErrataToolController()
-    with patch("pushsource._impl.backend.errata_source.ServerProxy") as mock_proxy:
-        mock_proxy.side_effect = controller.proxy
-        yield controller
-
-
-@fixture
-def fake_koji():
-    controller = FakeKojiController()
-    with patch("koji.ClientSession") as mock_session:
-        mock_session.side_effect = controller.session
-        yield controller
-
-
-@fixture
-def koji_dir(tmpdir):
-    yield str(tmpdir.mkdir("koji"))
 
 
 def test_errata_modules_via_koji(fake_errata_tool, fake_koji, koji_dir):

--- a/tests/errata/test_errata_rpms.py
+++ b/tests/errata/test_errata_rpms.py
@@ -1,9 +1,4 @@
 import os
-from pytest import raises, fixture
-from mock import patch
-
-from .fake_errata_tool import FakeErrataToolController
-from ..koji.fake_koji import FakeKojiController
 
 from pushsource import (
     Source,
@@ -13,27 +8,6 @@ from pushsource import (
     ErratumReference,
     RpmPushItem,
 )
-
-
-@fixture
-def fake_errata_tool():
-    controller = FakeErrataToolController()
-    with patch("pushsource._impl.backend.errata_source.ServerProxy") as mock_proxy:
-        mock_proxy.side_effect = controller.proxy
-        yield controller
-
-
-@fixture
-def fake_koji():
-    controller = FakeKojiController()
-    with patch("koji.ClientSession") as mock_session:
-        mock_session.side_effect = controller.session
-        yield controller
-
-
-@fixture
-def koji_dir(tmpdir):
-    yield str(tmpdir.mkdir("koji"))
 
 
 def test_errata_rpms_via_koji(fake_errata_tool, fake_koji, koji_dir):


### PR DESCRIPTION
fake_koji and fake_errata_tool were set up identically across
several tests. Adding them to conftest.py allows removing this
duplicate code.