### PR TITLE
errata: fix handling of XML-RPC URL where a path component is included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix usage of `errata` source when the an Errata Tool URL includes a path
+  component.
+
 ## [2.6.0] - 2021-05-27
 
 ### Added

--- a/src/pushsource/_impl/backend/errata_source.py
+++ b/src/pushsource/_impl/backend/errata_source.py
@@ -86,7 +86,7 @@ class ErrataSource(Source):
         # scheme we know is actually needed.
         parsed = parse.urlparse(self._url)
         base = "http://" + parsed.netloc
-        return os.path.join(base, parsed.path, "errata/errata_service")
+        return os.path.join(base + parsed.path, "errata/errata_service")
 
     def _koji_source(self, **kwargs):
         if not self._koji_source_url:

--- a/tests/errata/test_errata_metadata.py
+++ b/tests/errata/test_errata_metadata.py
@@ -163,3 +163,28 @@ def test_errata_typical_metadata(fake_errata_tool):
             ),
         ],
     )
+
+
+def test_errata_url_with_path(fake_errata_tool):
+    """Test fetching an advisory when the given ET URL has a path component."""
+
+    source = Source.get(
+        "errata:https://errata.example.com/foo/bar?errata=RHBA-2020:0518"
+    )
+
+    # It should not have tried to access ET yet (lazy fetching)
+    assert not fake_errata_tool.last_url
+
+    # Load all items
+    items = list(source)
+
+    # It should have queried the expected XML-RPC endpoint, which was
+    # appended to the URL retaining our path component.
+    # Note that our https was replaced with http, this is expected!
+    assert (
+        fake_errata_tool.last_url
+        == "http://errata.example.com/foo/bar/errata/errata_service"
+    )
+
+    # It should have got some data
+    assert items


### PR DESCRIPTION
Due to incorrect usage of os.path.join, if errata source was used
with a URL having a path component such as
https://errata.example.com/path, the hostname portion would be lost
and we'd try to construct an XML-RPC client with
"/path/errata/errata_service" as the URL.

Fix that by using os.path.join only on the needed components (we
don't need it when joining the parsed URL netloc and path back
together).