### PR TITLE
errata: convert and validate 'type' field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix usage of `errata` source when the an Errata Tool URL includes a path
   component.
 
+### Changed
+- On `ErratumPushItem`, the `type` attribute will now be automatically converted
+  from legacy values found in the wild such as "RHBA", "RHSA". Values are
+  now also validated.
+
 ## [2.6.0] - 2021-05-27
 
 ### Added

--- a/src/pushsource/_impl/model/conv.py
+++ b/src/pushsource/_impl/model/conv.py
@@ -106,6 +106,7 @@ def int2str(value):
     return value
 
 
+in_ = attr.validators.in_
 instance_of = attr.validators.instance_of
 instance_of_str = instance_of(six.string_types)
 optional = attr.validators.optional

--- a/tests/model/test_errata_type.py
+++ b/tests/model/test_errata_type.py
@@ -1,0 +1,26 @@
+import pytest
+
+from pushsource import ErratumPushItem
+
+
+@pytest.mark.parametrize(
+    "in_type,out_type",
+    [
+        ("RHBA", "bugfix"),
+        ("RHEA", "enhancement"),
+        ("RHSA", "security"),
+        ("bugfix", "bugfix"),
+        ("enhancement", "enhancement"),
+        ("security", "security"),
+    ],
+)
+def test_type_converted(in_type, out_type):
+    """ErratumPushItem converts values of 'type' field to one of the expected."""
+    item = ErratumPushItem(name="TEST-123", type=in_type)
+    assert item.type == out_type
+
+
+def test_type_enforced():
+    """ErratumPushItem complains on invalid values for 'type'"""
+    with pytest.raises(ValueError):
+        ErratumPushItem(name="TEST-123", type="oops-bad-type")


### PR DESCRIPTION
This field was documented as having values either "bugfix", "security"
or "enhancement", but there were a couple of issues with it:

- this was not enforced, so actually any values could appear there

- some ancient errata found in the wild use other values here, like
  "RHBA" and "RHSA"

Fix both of these by requiring that valid values are used, and
automatically converting known legacy values when data is loaded.