### PR TITLE
refactor: move modulemd filtering from errata source to koji source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix usage of `errata` source when the an Errata Tool URL includes a path
   component.
 
+### Added
+
+- Added `module_filter_filename` parameter to koji source, to select only a subset
+  of modulemd files from a build (e.g. limit to certain arches).
+
 ### Changed
 - On `ErratumPushItem`, the `type` attribute will now be automatically converted
   from legacy values found in the wild such as "RHBA", "RHSA". Values are

--- a/docs/sources/koji.rst
+++ b/docs/sources/koji.rst
@@ -54,6 +54,12 @@ text files as archives (shown as "Module Archives" in the Koji UI).
 
 ``koji:https://koji.fedoraproject.org/kojihub?module_build=flatpak-common-f32-3220200518173809.caf21102``
 
+If you want to process only a subset of the modules on the build
+(i.e. select only certain arches), you may use ``module_filter_filename`` to select
+the desired modulemd files, as in example:
+
+``koji:https://koji.fedoraproject.org/kojihub?module_build=flatpak-common-f32-3220200518173809.caf21102&module_filter_filename=modulemd.x86_64.txt,modulemd.s390x.txt``
+
 
 Setting the destination for push items
 ......................................

--- a/src/pushsource/_impl/backend/errata_source.py
+++ b/src/pushsource/_impl/backend/errata_source.py
@@ -152,16 +152,13 @@ class ErrataSource(Source):
         modules = build_info.get("modules") or {}
 
         # Get a koji source which will yield all modules from the build
-        koji_source = self._koji_source(module_build=[build_nvr])
+        koji_source = self._koji_source(
+            module_build=[build_nvr], module_filter_filename=list(modules.keys())
+        )
 
         out = []
 
         for push_item in koji_source:
-            # The koji source yielded *all* modulemds on the build.
-            # We filter to only those requested by Errata Tool.
-            if push_item.name not in modules:
-                continue
-
             dest = modules[push_item.name]
 
             # Fill in more push item details based on the info provided by ET.

--- a/tests/koji/conftest.py
+++ b/tests/koji/conftest.py
@@ -1,0 +1,17 @@
+from pytest import fixture
+from mock import patch
+
+from .fake_koji import FakeKojiController
+
+
+@fixture
+def fake_koji():
+    controller = FakeKojiController()
+    with patch("koji.ClientSession") as mock_session:
+        mock_session.side_effect = controller.session
+        yield controller
+
+
+@fixture
+def koji_dir(tmpdir):
+    yield str(tmpdir.mkdir("koji"))

--- a/tests/koji/test_koji.py
+++ b/tests/koji/test_koji.py
@@ -1,24 +1,8 @@
 import os
 
-from pytest import raises, fixture
-from mock import patch
+from pytest import raises
 
 from pushsource import Source, RpmPushItem
-
-from .fake_koji import FakeKojiController
-
-
-@fixture
-def fake_koji():
-    controller = FakeKojiController()
-    with patch("koji.ClientSession") as mock_session:
-        mock_session.side_effect = controller.session
-        yield controller
-
-
-@fixture
-def koji_dir(tmpdir):
-    yield str(tmpdir.mkdir("koji"))
 
 
 def test_koji_needs_url():

--- a/tests/koji/test_koji_module.py
+++ b/tests/koji/test_koji_module.py
@@ -1,0 +1,84 @@
+import os
+
+from pytest import raises, fixture
+from mock import patch
+
+from pushsource import Source, ModuleMdPushItem
+
+from .fake_koji import FakeKojiController
+
+
+def test_koji_modules(fake_koji, koji_dir):
+    """Koji source yields requested modules"""
+
+    source = Source.get(
+        "koji:https://koji.example.com/?module_build=foo-1.0-1", basedir=koji_dir
+    )
+
+    fake_koji.insert_rpms(["foo-1.0-1.x86_64.rpm"], build_nvr="foo-1.0-1")
+    fake_koji.insert_modules(
+        ["modulemd.x86_64.txt", "modulemd.s390x.txt"], build_nvr="foo-1.0-1"
+    )
+
+    # Eagerly fetch
+    items = list(source)
+
+    # It should have returned push items for the two modules
+    assert len(items) == 2
+
+    items = sorted(items, key=lambda pi: pi.name)
+
+    assert items[0] == ModuleMdPushItem(
+        name="modulemd.s390x.txt",
+        state="PENDING",
+        src=os.path.join(
+            koji_dir, "packages/foo/1.0/1/files/module/modulemd.s390x.txt"
+        ),
+        dest=[],
+        md5sum=None,
+        sha256sum=None,
+        origin=None,
+        build="foo-1.0-1",
+        signing_key=None,
+    )
+
+    assert items[1] == ModuleMdPushItem(
+        name="modulemd.x86_64.txt",
+        state="PENDING",
+        src=os.path.join(
+            koji_dir, "packages/foo/1.0/1/files/module/modulemd.x86_64.txt"
+        ),
+        dest=[],
+        md5sum=None,
+        sha256sum=None,
+        origin=None,
+        build="foo-1.0-1",
+        signing_key=None,
+    )
+
+
+def test_koji_modules_filter_filename(fake_koji, koji_dir):
+    """Koji source can filter modules by filename"""
+
+    source = Source.get(
+        "koji:https://koji.example.com/?module_build=foo-1.0-1",
+        basedir=koji_dir,
+        module_filter_filename="modulemd.x86_64.txt,modulemd.aarch64.txt",
+    )
+
+    fake_koji.insert_rpms(["foo-1.0-1.x86_64.rpm"], build_nvr="foo-1.0-1")
+    fake_koji.insert_modules(
+        ["modulemd.x86_64.txt", "modulemd.aarch64.txt", "modulemd.s390x.txt"],
+        build_nvr="foo-1.0-1",
+    )
+
+    # Eagerly fetch
+    items = list(source)
+
+    # It should have returned push items for the two modules which matched filter
+    assert len(items) == 2
+
+    item_names = sorted([item.name for item in items])
+
+    # Should be only those two matching the filter
+    assert item_names == ["modulemd.aarch64.txt", "modulemd.x86_64.txt"]


### PR DESCRIPTION
ET requests modules by filename, e.g. modulemd.x86_64.txt.

Previously, we had errata source query koji source and then filter
the returned values according to ET's desired filenames. Let's
instead make koji source natively support filtering by way of a new
parameter.

Motivation: koji source will soon need to start parsing these
modulemd files so that the NSVCA can be put onto push items.
If we do this for files which will be then filtered by the errata
source, we're negatively impacting the performance and reliability
by loading data we don't need. It's better if we can tell koji
source in advance exactly which files we're interested in.