### PR TITLE
koji: use NSVCA as module push item name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of modulemd files from a build (e.g. limit to certain arches).
 
 ### Changed
+
 - On `ErratumPushItem`, the `type` attribute will now be automatically converted
   from legacy values found in the wild such as "RHBA", "RHSA". Values are
   now also validated.
+- `ModuleMdPushItem.name` now uses the NSVCA of a module rather than the filename of
+  a loaded modulemd file, when this metadata is available.
 
 ## [2.6.0] - 2021-05-27
 

--- a/src/pushsource/_impl/backend/modulemd.py
+++ b/src/pushsource/_impl/backend/modulemd.py
@@ -1,0 +1,42 @@
+# Utilities for dealing with modulemd files from backends.
+# None of this is public API.
+import yaml
+
+from .. import compat_attr as attr
+
+
+@attr.s()
+class Module(object):
+    MOD_NSVCA_FMT = "{name}:{stream}:{version}:{context}:{arch}"
+
+    name = attr.ib()
+    stream = attr.ib()
+    version = attr.ib()
+    context = attr.ib()
+    arch = attr.ib()
+
+    @property
+    def nsvca(self):
+        return self.MOD_NSVCA_FMT.format(
+            name=self.name,
+            stream=self.stream,
+            version=self.version,
+            context=self.context,
+            arch=self.arch,
+        )
+
+    @classmethod
+    def from_file(cls, fname):
+        # Obtain a Module instance from a YAML file.
+        # Raises if file doesn't contain a module or has multiple documents.
+        with open(fname) as f:
+            parsed = yaml.load(f, Loader=yaml.BaseLoader)
+        data = parsed["data"]
+
+        return cls(
+            name=data["name"],
+            stream=data["stream"],
+            version=data["version"],
+            context=data["context"],
+            arch=data["arch"],
+        )

--- a/tests/koji/data/modulemd-multiple.yaml
+++ b/tests/koji/data/modulemd-multiple.yaml
@@ -1,0 +1,139 @@
+---
+document: modulemd
+version: 2
+data:
+  name: tomcat
+  stream: "master"
+  version: 3220200215013612
+  context: 4c391d95
+  arch: x86_64
+  summary: Apache Servlet/JSP Engine, RI for Servlet 4.0/JSP 2.3 API
+  description: >-
+    Tomcat is the servlet container that is used in the official Reference Implementation
+    for the Java Servlet and JavaServer Pages technologies. The Java Servlet and JavaServer
+    Pages specifications are developed by Sun under the Java Community Process.
+  license:
+    module:
+    - MIT
+    content:
+    - ASL 2.0
+    - EPL-2.0
+  xmd: {}
+  dependencies:
+  - buildrequires:
+      platform: [f32]
+    requires:
+      javapackages-tools: []
+      platform: [f32]
+  profiles:
+    default:
+      description: A minimal tomcat installation.
+      rpms:
+      - tomcat
+      - tomcat-el-3.0-api
+      - tomcat-jsp-2.3-api
+      - tomcat-lib
+      - tomcat-servlet-4.0-api
+  api:
+    rpms:
+    - tomcat
+    - tomcat-el-3.0-api
+    - tomcat-jsp-2.3-api
+    - tomcat-lib
+    - tomcat-servlet-4.0-api
+  components:
+    rpms:
+      ecj:
+        rationale: Required for building JSPs at Runtime.
+        ref: master
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+      tomcat:
+        rationale: Provides core server functionality.
+        ref: master
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+  artifacts:
+    rpms:
+    - ecj-1:4.14-3.module_f32+8023+0534a12a.noarch
+    - ecj-1:4.14-3.module_f32+8023+0534a12a.src
+    - tomcat-1:9.0.30-2.module_f32+8023+0534a12a.noarch
+    - tomcat-1:9.0.30-2.module_f32+8023+0534a12a.src
+    - tomcat-admin-webapps-1:9.0.30-2.module_f32+8023+0534a12a.noarch
+    - tomcat-docs-webapp-1:9.0.30-2.module_f32+8023+0534a12a.noarch
+    - tomcat-el-3.0-api-1:9.0.30-2.module_f32+8023+0534a12a.noarch
+    - tomcat-jsp-2.3-api-1:9.0.30-2.module_f32+8023+0534a12a.noarch
+    - tomcat-jsvc-1:9.0.30-2.module_f32+8023+0534a12a.noarch
+    - tomcat-lib-1:9.0.30-2.module_f32+8023+0534a12a.noarch
+    - tomcat-servlet-4.0-api-1:9.0.30-2.module_f32+8023+0534a12a.noarch
+    - tomcat-webapps-1:9.0.30-2.module_f32+8023+0534a12a.noarch
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+  module: varnish
+  profiles:
+    6: [common]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: varnish
+  stream: "6.0"
+  version: 3220200215073318
+  context: 43bbeeef
+  arch: x86_64
+  summary: Varnish HTTP cache
+  description: >-
+    Varnish Cache web application accelerator
+  license:
+    module:
+    - MIT
+    content:
+    - BSD
+  xmd: {}
+  dependencies:
+  - buildrequires:
+      platform: [f32]
+    requires:
+      platform: [f32]
+  references:
+    documentation: http://varnish-cache.org/docs/
+    tracker: https://github.com/varnishcache/varnish-cache/issues
+  profiles:
+    default:
+      rpms:
+      - varnish
+      - varnish-modules
+  api:
+    rpms:
+    - varnish
+    - varnish-modules
+  buildopts:
+    rpms:
+      macros: >
+        %_without_python2 1
+
+        %_with_python3 1
+  components:
+    rpms:
+      varnish:
+        rationale: Module API.
+        ref: stream-6.0
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+      varnish-modules:
+        rationale: Extension modules.
+        ref: stream-6.0
+        buildorder: 1
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+  artifacts:
+    rpms:
+    - varnish-0:6.0.6-1.module_f32+7891+54364fee.src
+    - varnish-0:6.0.6-1.module_f32+7891+54364fee.x86_64
+    - varnish-devel-0:6.0.6-1.module_f32+7891+54364fee.x86_64
+    - varnish-docs-0:6.0.6-1.module_f32+7891+54364fee.x86_64
+    - varnish-modules-0:0.15.0-9.module_f32+7891+54364fee.src
+    - varnish-modules-0:0.15.0-9.module_f32+7891+54364fee.x86_64
+    - varnish-modules-debuginfo-0:0.15.0-9.module_f32+7891+54364fee.x86_64
+    - varnish-modules-debugsource-0:0.15.0-9.module_f32+7891+54364fee.x86_64
+...

--- a/tests/koji/data/modulemd-varnish-x86_64.yaml
+++ b/tests/koji/data/modulemd-varnish-x86_64.yaml
@@ -1,0 +1,63 @@
+---
+document: modulemd
+version: 2
+data:
+  name: varnish
+  stream: "6.0"
+  version: 3220200215073318
+  context: 43bbeeef
+  arch: x86_64
+  summary: Varnish HTTP cache
+  description: >-
+    Varnish Cache web application accelerator
+  license:
+    module:
+    - MIT
+    content:
+    - BSD
+  xmd: {}
+  dependencies:
+  - buildrequires:
+      platform: [f32]
+    requires:
+      platform: [f32]
+  references:
+    documentation: http://varnish-cache.org/docs/
+    tracker: https://github.com/varnishcache/varnish-cache/issues
+  profiles:
+    default:
+      rpms:
+      - varnish
+      - varnish-modules
+  api:
+    rpms:
+    - varnish
+    - varnish-modules
+  buildopts:
+    rpms:
+      macros: >
+        %_without_python2 1
+
+        %_with_python3 1
+  components:
+    rpms:
+      varnish:
+        rationale: Module API.
+        ref: stream-6.0
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+      varnish-modules:
+        rationale: Extension modules.
+        ref: stream-6.0
+        buildorder: 1
+        arches: [aarch64, armv7hl, i686, ppc64le, s390x, x86_64]
+  artifacts:
+    rpms:
+    - varnish-0:6.0.6-1.module_f32+7891+54364fee.src
+    - varnish-0:6.0.6-1.module_f32+7891+54364fee.x86_64
+    - varnish-devel-0:6.0.6-1.module_f32+7891+54364fee.x86_64
+    - varnish-docs-0:6.0.6-1.module_f32+7891+54364fee.x86_64
+    - varnish-modules-0:0.15.0-9.module_f32+7891+54364fee.src
+    - varnish-modules-0:0.15.0-9.module_f32+7891+54364fee.x86_64
+    - varnish-modules-debuginfo-0:0.15.0-9.module_f32+7891+54364fee.x86_64
+    - varnish-modules-debugsource-0:0.15.0-9.module_f32+7891+54364fee.x86_64
+...

--- a/tests/koji/test_koji_module.py
+++ b/tests/koji/test_koji_module.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import textwrap
 
 from pytest import raises, fixture
 from mock import patch
@@ -6,6 +8,9 @@ from mock import patch
 from pushsource import Source, ModuleMdPushItem
 
 from .fake_koji import FakeKojiController
+
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
 
 def test_koji_modules(fake_koji, koji_dir):
@@ -17,18 +22,28 @@ def test_koji_modules(fake_koji, koji_dir):
 
     fake_koji.insert_rpms(["foo-1.0-1.x86_64.rpm"], build_nvr="foo-1.0-1")
     fake_koji.insert_modules(
-        ["modulemd.x86_64.txt", "modulemd.s390x.txt"], build_nvr="foo-1.0-1"
+        ["modulemd.x86_64.txt", "modulemd.s390x.txt", "modulemd.src.txt"],
+        build_nvr="foo-1.0-1",
     )
+
+    # Set up an existing modulemd file for one of the items and not the others.
+    modulemd_path = os.path.join(
+        koji_dir, "packages/foo/1.0/1/files/module/modulemd.x86_64.txt"
+    )
+    os.makedirs(os.path.dirname(modulemd_path))
+    shutil.copy(os.path.join(DATA_DIR, "modulemd-varnish-x86_64.yaml"), modulemd_path)
 
     # Eagerly fetch
     items = list(source)
 
-    # It should have returned push items for the two modules
-    assert len(items) == 2
+    # It should have returned push items for the modules
+    assert len(items) == 3
 
     items = sorted(items, key=lambda pi: pi.name)
 
     assert items[0] == ModuleMdPushItem(
+        # For this module, the file didn't exist and we used the filename as module name
+        # since metadata is unavailable.
         name="modulemd.s390x.txt",
         state="PENDING",
         src=os.path.join(
@@ -43,7 +58,23 @@ def test_koji_modules(fake_koji, koji_dir):
     )
 
     assert items[1] == ModuleMdPushItem(
-        name="modulemd.x86_64.txt",
+        # For this module, no attempt was made to parse it since it's a modulemd
+        # source file rather than a built module.
+        name="modulemd.src.txt",
+        state="PENDING",
+        src=os.path.join(koji_dir, "packages/foo/1.0/1/files/module/modulemd.src.txt"),
+        dest=[],
+        md5sum=None,
+        sha256sum=None,
+        origin=None,
+        build="foo-1.0-1",
+        signing_key=None,
+    )
+
+    assert items[2] == ModuleMdPushItem(
+        # For this module, the file existed and was parseable, so we use the
+        # proper NSVCA as the push item name.
+        name="varnish:6.0:3220200215073318:43bbeeef:x86_64",
         state="PENDING",
         src=os.path.join(
             koji_dir, "packages/foo/1.0/1/files/module/modulemd.x86_64.txt"
@@ -55,6 +86,73 @@ def test_koji_modules(fake_koji, koji_dir):
         build="foo-1.0-1",
         signing_key=None,
     )
+
+
+def test_koji_multiple_in_stream(fake_koji, koji_dir, caplog):
+    """Koji source fails if referenced modulemd file contains multiple modules.
+
+    This isn't something expected to happen in practice. The point of this test is to
+    ensure that, if it *does* happen, we fail in a controlled manner rather than
+    something odd like silently using the first module in the stream.
+    """
+
+    source = Source.get(
+        "koji:https://koji.example.com/?module_build=foo-1.0-1", basedir=koji_dir
+    )
+
+    fake_koji.insert_rpms(["foo-1.0-1.x86_64.rpm"], build_nvr="foo-1.0-1")
+    fake_koji.insert_modules(["modulemd.x86_64.txt"], build_nvr="foo-1.0-1")
+
+    # Set up a modulemd stream with multiple documents for this file.
+    modulemd_path = os.path.join(
+        koji_dir, "packages/foo/1.0/1/files/module/modulemd.x86_64.txt"
+    )
+    os.makedirs(os.path.dirname(modulemd_path))
+    shutil.copy(os.path.join(DATA_DIR, "modulemd-multiple.yaml"), modulemd_path)
+
+    # Trying to fetch the items should fail
+    with raises(Exception) as exc_info:
+        list(source)
+
+    # We should find a relevant message from YAML parser
+    assert "expected a single document in the stream" in str(exc_info)
+
+    # It should have told us exactly which file in which build couldn't be parsed
+    expected_message = (
+        "In koji build foo-1.0-1, cannot load module metadata from " + modulemd_path
+    )
+    assert expected_message in caplog.messages
+
+
+def test_koji_bad_modulemd(fake_koji, koji_dir, caplog):
+    """Koji source logs and raises exception on unparseable modulemd file"""
+
+    source = Source.get(
+        "koji:https://koji.example.com/?module_build=foo-1.0-1", basedir=koji_dir
+    )
+
+    fake_koji.insert_rpms(["foo-1.0-1.x86_64.rpm"], build_nvr="foo-1.0-1")
+    fake_koji.insert_modules(
+        ["modulemd.x86_64.txt", "modulemd.s390x.txt"], build_nvr="foo-1.0-1"
+    )
+
+    # Write invalid modulemd here.
+    modulemd_path = os.path.join(
+        koji_dir, "packages/foo/1.0/1/files/module/modulemd.x86_64.txt"
+    )
+    os.makedirs(os.path.dirname(modulemd_path))
+    with open(modulemd_path, "wt") as f:
+        f.write("This ain't no valid modulemd")
+
+    # Trying to fetch the items should fail
+    with raises(Exception):
+        list(source)
+
+    # And it should have told us exactly which file in which build couldn't be parsed
+    expected_message = (
+        "In koji build foo-1.0-1, cannot load module metadata from " + modulemd_path
+    )
+    assert expected_message in caplog.messages
 
 
 def test_koji_modules_filter_filename(fake_koji, koji_dir):


### PR DESCRIPTION
Testing this code with Pub revealed a behavior difference: in Pub
code, we load modulemd files and use their NSVCA as the push item
name. In this library we were not doing that, and instead using
the modulemd filename as push item name.

Although it's a bit annoying that we have to parse the modulemd
files before we can return push items, overall the Pub behavior
seems better as the NSVCA is a much better identifier for what's
being pushed than a generic filename like modulemd.<arch>.txt.
So let's do the same here.

As a compromise, we still use the filename as a fallback when the
file isn't available. This is done since loading the file needs
koji's NFS volume available, which is true in production but won't
be the case in many development and testing scenarios.