### PR TITLE
errata: support FTP paths for RPMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now also validated.
 - `ModuleMdPushItem.name` now uses the NSVCA of a module rather than the filename of
   a loaded modulemd file, when this metadata is available.
+- `errata` source now includes FTP paths in the `dest` field of generated push items,
+  where applicable.
 
 ## [2.6.0] - 2021-05-27
 

--- a/src/pushsource/_impl/backend/errata_source/__init__.py
+++ b/src/pushsource/_impl/backend/errata_source/__init__.py
@@ -1,0 +1,1 @@
+from .errata_source import ErrataSource

--- a/src/pushsource/_impl/backend/errata_source/errata_client.py
+++ b/src/pushsource/_impl/backend/errata_source/errata_client.py
@@ -1,0 +1,56 @@
+import logging
+import threading
+from functools import partial
+
+from six.moves import xmlrpc_client
+from more_executors import Executors
+from more_executors.futures import f_zip, f_map
+
+from ...compat_attr import attr
+
+LOG = logging.getLogger("pushsource.errata_client")
+
+
+@attr.s()
+class ErrataRaw(object):
+    # Helper to collect raw responses of all ET APIs for a single advisory
+    advisory_cdn_metadata = attr.ib(type=dict)
+    advisory_cdn_file_list = attr.ib(type=dict)
+    ftp_paths = attr.ib(type=dict)
+
+
+class ErrataClient(object):
+    def __init__(self, threads, url):
+        self._executor = Executors.thread_pool(max_workers=threads).with_retry()
+        self._url = url
+        self._tls = threading.local()
+
+        self._get_advisory_cdn_metadata = partial(
+            self._call_et, "get_advisory_cdn_metadata"
+        )
+        self._get_advisory_cdn_file_list = partial(
+            self._call_et, "get_advisory_cdn_file_list"
+        )
+        self._get_ftp_paths = partial(self._call_et, "get_ftp_paths")
+
+    @property
+    def _errata_service(self):
+        # XML-RPC client connected to errata_service.
+        # Each thread uses a separate client.
+        if not hasattr(self._tls, "errata_service"):
+            LOG.debug("Creating XML-RPC client for Errata Tool: %s", self._url)
+            self._tls.errata_service = xmlrpc_client.ServerProxy(self._url)
+        return self._tls.errata_service
+
+    def get_raw_f(self, advisory_id):
+        """Returns Future[ErrataRaw] holding all ET responses for a particular advisory."""
+        all_responses = f_zip(
+            self._executor.submit(self._get_advisory_cdn_metadata, advisory_id),
+            self._executor.submit(self._get_advisory_cdn_file_list, advisory_id),
+            self._executor.submit(self._get_ftp_paths, advisory_id),
+        )
+        return f_map(all_responses, lambda tup: ErrataRaw(*tup))
+
+    def _call_et(self, method_name, advisory_id):
+        method = getattr(self._errata_service, method_name)
+        return method(advisory_id)

--- a/tests/errata/conftest.py
+++ b/tests/errata/conftest.py
@@ -8,7 +8,9 @@ from ..koji.fake_koji import FakeKojiController
 @fixture
 def fake_errata_tool():
     controller = FakeErrataToolController()
-    with patch("pushsource._impl.backend.errata_source.ServerProxy") as mock_proxy:
+    with patch(
+        "pushsource._impl.backend.errata_source.errata_client.xmlrpc_client.ServerProxy"
+    ) as mock_proxy:
         mock_proxy.side_effect = controller.proxy
         yield controller
 

--- a/tests/errata/data/RHEA-2020:0346.yaml
+++ b/tests/errata/data/RHEA-2020:0346.yaml
@@ -1,4 +1,5 @@
 advisory_id: RHEA-2020:0346
+
 cdn_file_list:
   postgresql-12-8010120191120141335.e4e244f9:
     checksums:
@@ -523,6 +524,7 @@ cdn_file_list:
       postgresql-upgrade-devel-debuginfo-12.1-2.module+el8.1.1+4794+c82b6e09.x86_64.rpm:
       - rhel-8-for-x86_64-appstream-debug-rpms__8
     sig_key: fd431d51
+
 cdn_metadata:
   description: 'This enhancement update adds the postgresql:12 module stream to Red
     Hat Enterprise Linux 8. (BZ#1721822)
@@ -2235,3 +2237,16 @@ cdn_metadata:
   type: enhancement
   updated: 2020-02-04 11:39:30 UTC
   version: '4'
+
+ftp_paths:
+  postgresql-12-8010120191120141335.e4e244f9:
+    sig_key: fd431d51
+    rpms:
+      pgaudit-1.4.0-4.module+el8.1.1+4794+c82b6e09.src.rpm:
+      - /ftp/pub/redhat/linux/enterprise/AppStream-8.1.1.MAIN/en/os/SRPMS/
+      postgresql-12.1-2.module+el8.1.1+4794+c82b6e09.src.rpm:
+      - /ftp/pub/redhat/linux/enterprise/AppStream-8.1.1.MAIN/en/os/SRPMS/
+      postgres-decoderbufs-0.10.0-2.module+el8.1.1+4794+c82b6e09.src.rpm:
+      - /ftp/pub/redhat/linux/enterprise/AppStream-8.1.1.MAIN/en/os/SRPMS/
+    modules:
+    - /ftp/pub/redhat/linux/enterprise/AppStream-8.1.1.MAIN/en/os/modules/

--- a/tests/errata/fake_errata_tool.py
+++ b/tests/errata/fake_errata_tool.py
@@ -42,10 +42,13 @@ class FakeErrataToolProxy(object):
         out = self._ctrl._data[advisory_id]
         if out is None:
             raise Fault(100, "No such advisory: %s" % advisory_id)
-        return out[key]
+        return out.get(key, {})
 
     def get_advisory_cdn_file_list(self, advisory_id):
         return self._get_data(advisory_id, "cdn_file_list")
 
     def get_advisory_cdn_metadata(self, advisory_id):
         return self._get_data(advisory_id, "cdn_metadata")
+
+    def get_ftp_paths(self, advisory_id):
+        return self._get_data(advisory_id, "ftp_paths")

--- a/tests/errata/test_errata_modules.py
+++ b/tests/errata/test_errata_modules.py
@@ -199,6 +199,44 @@ def test_errata_modules_via_koji(fake_errata_tool, fake_koji, koji_dir):
     found_rpm_names = [item.name for item in rpm_items]
     assert sorted(found_rpm_names) == sorted(rpm_filenames)
 
+    # FTP paths should also be reflected in RPM dests; we'll just check
+    # src RPMs since those are the only ones with FTP paths
+    src_rpms = sorted(
+        [(i.name, sorted(i.dest)) for i in rpm_items if i.name.endswith(".src.rpm")]
+    )
+    assert src_rpms == [
+        (
+            "pgaudit-1.4.0-4.module+el8.1.1+4794+c82b6e09.src.rpm",
+            [
+                "/ftp/pub/redhat/linux/enterprise/AppStream-8.1.1.MAIN/en/os/SRPMS/",
+                "rhel-8-for-aarch64-appstream-source-rpms__8",
+                "rhel-8-for-ppc64le-appstream-source-rpms__8",
+                "rhel-8-for-s390x-appstream-source-rpms__8",
+                "rhel-8-for-x86_64-appstream-source-rpms__8",
+            ],
+        ),
+        (
+            "postgres-decoderbufs-0.10.0-2.module+el8.1.1+4794+c82b6e09.src.rpm",
+            [
+                "/ftp/pub/redhat/linux/enterprise/AppStream-8.1.1.MAIN/en/os/SRPMS/",
+                "rhel-8-for-aarch64-appstream-source-rpms__8",
+                "rhel-8-for-ppc64le-appstream-source-rpms__8",
+                "rhel-8-for-s390x-appstream-source-rpms__8",
+                "rhel-8-for-x86_64-appstream-source-rpms__8",
+            ],
+        ),
+        (
+            "postgresql-12.1-2.module+el8.1.1+4794+c82b6e09.src.rpm",
+            [
+                "/ftp/pub/redhat/linux/enterprise/AppStream-8.1.1.MAIN/en/os/SRPMS/",
+                "rhel-8-for-aarch64-appstream-source-rpms__8",
+                "rhel-8-for-ppc64le-appstream-source-rpms__8",
+                "rhel-8-for-s390x-appstream-source-rpms__8",
+                "rhel-8-for-x86_64-appstream-source-rpms__8",
+            ],
+        ),
+    ]
+
     # It should have found the modulemd files
     assert sorted(modulemd_items, key=lambda item: item.src) == [
         ModuleMdPushItem(


### PR DESCRIPTION
Integrate support for get_ftp_paths API into errata backend.

This can now result in the 'dest' for one RPM push item having
a mixture of rhsm-pulp repo IDs and FTP paths. This will allow
alt-src pushes to work on top of errata backend.

Other tweaks include:

- drop the 'target' argument to errata backend (which was not used).
  It seems we ought not to need this.

  For now the design now is that the source will give you back all
  kinds of destinations (and if you only want to deal with certain
  types, e.g. you don't want the ftp paths, you need to filter them
  yourself). It's possible some optional filtering arguments will be
  added here later.

- separate the low-level code which calls ET methods into a new
  errata_client module

Note: the backend remains marked as a technical preview with
no stability guarantee.