### PR TITLE
errata: add module_build onto RPM push items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+
+- Added `module_build` attribute to RPM push items.
 
 ## [2.7.0] - 2021-06-10
 

--- a/src/pushsource/_impl/model/rpm.py
+++ b/src/pushsource/_impl/model/rpm.py
@@ -1,7 +1,34 @@
 from .base import PushItem
+from .conv import optional_str
 from .. import compat_attr as attr
 
 
 @attr.s()
 class RpmPushItem(PushItem):
     """A :class:`~pushsource.PushItem` representing a single RPM."""
+
+    module_build = attr.ib(type=str, default=None, validator=optional_str)
+    """NVR for the koji module build through which this push item was located, if any.
+
+    For a modular RPM push item, there may be two koji builds in play:
+
+    ``module_build`` (this attribute):
+        NVR of a build which produced modulemd YAML files referencing this RPM
+        (but the build itself does not contain RPMs).
+
+        Example: `ghc-8.4-820200708061905.9edba152`_
+        is a valid `module_build` for ``ghc-8.4.4-74.module_el8+12161+cf1bd7f2.x86_64.rpm``.
+
+    :meth:`~pushsource.PushItem.build`:
+        NVR of the build containing the RPM.
+
+        Example: `ghc-8.4.4-74.module_el8+12161+cf1bd7f2`_
+        is a valid build for ``ghc-8.4.4-74.module_el8+12161+cf1bd7f2.x86_64.rpm``.
+
+    Note that the ``module_build`` itself isn't a property of the RPM but rather should
+    be considered contextual information on how any given RPM was located. The same RPM
+    may have different values of ``module_build`` when loaded from different contexts.
+
+    .. _ghc-8.4-820200708061905.9edba152: https://koji.fedoraproject.org/koji/buildinfo?buildID=1767200
+    .. _ghc-8.4.4-74.module_el8+12161+cf1bd7f2: https://koji.fedoraproject.org/koji/buildinfo?buildID=1767130
+    """

--- a/tests/errata/test_errata_modules.py
+++ b/tests/errata/test_errata_modules.py
@@ -153,7 +153,7 @@ def test_errata_modules_via_koji(fake_errata_tool, fake_koji, koji_dir):
         rpm_filenames,
         koji_dir=koji_dir,
         signing_key="fd431d51",
-        build_nvr="postgresql-12-8010120191120141335.e4e244f9",
+        build_nvr="postgresql-12.1-2.module+el8.1.1+4794+c82b6e09",
     )
 
     # Insert archives referenced by build
@@ -198,6 +198,21 @@ def test_errata_modules_via_koji(fake_errata_tool, fake_koji, koji_dir):
     # It should have found all the RPMs
     found_rpm_names = [item.name for item in rpm_items]
     assert sorted(found_rpm_names) == sorted(rpm_filenames)
+
+    # The RPMs should maintain their own build and module build correctly
+    found_rpm_module_build = set(
+        [(item.build, item.module_build) for item in rpm_items]
+    )
+    assert found_rpm_module_build == set(
+        [
+            (
+                # The build containing the RPM
+                "postgresql-12.1-2.module+el8.1.1+4794+c82b6e09",
+                # The build containing the modulemds (as passed by ET)
+                "postgresql-12-8010120191120141335.e4e244f9",
+            )
+        ]
+    )
 
     # FTP paths should also be reflected in RPM dests; we'll just check
     # src RPMs since those are the only ones with FTP paths


### PR DESCRIPTION
When we're dealing with modular RPMs loaded via ET, there are two
relevant builds in koji:

- build containing RPMs
- build containing modulemds

We had not previously made the latter available anywhere. Add it
to a new attribute because some alt-src use-cases need it.