### PR TITLE
errata: support filtering RPMs by arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `module_build` attribute to RPM push items.
+- Added `rpm_filter_arch` parameter to errata source, to select a subset of RPMs
+  by architecture.
 
 ## [2.7.0] - 2021-06-10
 

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -176,12 +176,8 @@ class KojiSource(Source):
         self._url = url
         self._rpm = [try_int(x) for x in list_argument(rpm)]
         self._module_build = [try_int(x) for x in list_argument(module_build)]
-        self._module_filter_filename = (
-            # retain None values so we can differentiate between
-            # "caller asked for empty filter" vs "caller did not ask for any filter"
-            list_argument(module_filter_filename)
-            if module_filter_filename is not None
-            else None
+        self._module_filter_filename = list_argument(
+            module_filter_filename, retain_none=True
         )
         self._signing_key = list_argument(signing_key)
         self._dest = list_argument(dest)

--- a/src/pushsource/_impl/helpers.py
+++ b/src/pushsource/_impl/helpers.py
@@ -1,10 +1,12 @@
 import six
 
 
-def list_argument(value):
+def list_argument(value, retain_none=False):
     """Convert an argument into a list:
 
     - if the value is already a list, it's returned verbatim
+    - if the value is None and retain_none is False, an empty list is returned
+    - if the value is None and retain_none is True, None is returned
     - if the value is a string, it's split on ","
     - otherwise, the value is wrapped in a list
 
@@ -18,8 +20,12 @@ def list_argument(value):
     Returns:
         list
             ``value`` converted to or wrapped into a list.
+        None
+            if input was None and retain_none is True.
     """
     if isinstance(value, list):
+        return value
+    if value is None and retain_none:
         return value
     if not value:
         return []

--- a/src/pushsource/_impl/model/conv.py
+++ b/src/pushsource/_impl/model/conv.py
@@ -92,6 +92,15 @@ sha1str = partial(hexstr, 40)
 sha256str = partial(hexstr, 64)
 
 
+def archstr(value):
+    """Convert a handful of arch aliases into canonical form for consistent comparisons."""
+    if value == "amd64":
+        return "x86_64"
+    if value == "SRPM":
+        return "src"
+    return value
+
+
 def upper_if_str(value):
     if isinstance(value, six.string_types):
         return value.upper()

--- a/tests/errata/test_errata_rpms_filter.py
+++ b/tests/errata/test_errata_rpms_filter.py
@@ -1,0 +1,150 @@
+import os
+
+import pytest
+
+from pushsource import Source, RpmPushItem
+
+
+@pytest.fixture
+def source_factory(fake_errata_tool, fake_koji, koji_dir):
+    # Yields constructor for an errata source pointing at a valid advisory with RPMs,
+    # with no arch filter set. Tests can then provide a specific filter and observe
+    # the results.
+    source_ctor = Source.get_partial(
+        "errata:https://errata.example.com",
+        errata="RHSA-2020:0509",
+        koji_source="koji:https://koji.example.com?basedir=%s" % koji_dir,
+    )
+
+    # Insert koji RPMs referenced by this advisory
+    fake_koji.rpm_data["sudo-1.8.25p1-4.el8_0.3.ppc64le.rpm"] = {
+        "arch": "ppc64le",
+        "name": "sudo",
+        "version": "1.8.25p1",
+        "release": "4.el8_0.3",
+        "build_id": 1234,
+    }
+    fake_koji.rpm_data["sudo-1.8.25p1-4.el8_0.3.x86_64.rpm"] = {
+        "arch": "x86_64",
+        "name": "sudo",
+        "version": "1.8.25p1",
+        "release": "4.el8_0.3",
+        "build_id": 1234,
+    }
+    fake_koji.rpm_data["sudo-1.8.25p1-4.el8_0.3.src.rpm"] = {
+        "arch": "src",
+        "name": "sudo",
+        "version": "1.8.25p1",
+        "release": "4.el8_0.3",
+        "build_id": 1234,
+    }
+    fake_koji.rpm_data["sudo-debuginfo-1.8.25p1-4.el8_0.3.ppc64le.rpm"] = {
+        "arch": "ppc64le",
+        "name": "sudo-debuginfo",
+        "version": "1.8.25p1",
+        "release": "4.el8_0.3",
+        "build_id": 1234,
+    }
+    fake_koji.rpm_data["sudo-debuginfo-1.8.25p1-4.el8_0.3.x86_64.rpm"] = {
+        "arch": "x86_64",
+        "name": "sudo-debuginfo",
+        "version": "1.8.25p1",
+        "release": "4.el8_0.3",
+        "build_id": 1234,
+    }
+    fake_koji.rpm_data["sudo-debugsource-1.8.25p1-4.el8_0.3.ppc64le.rpm"] = {
+        "arch": "ppc64le",
+        "name": "sudo-debugsource",
+        "version": "1.8.25p1",
+        "release": "4.el8_0.3",
+        "build_id": 1234,
+    }
+    fake_koji.rpm_data["sudo-debugsource-1.8.25p1-4.el8_0.3.x86_64.rpm"] = {
+        "arch": "x86_64",
+        "name": "sudo-debugsource",
+        "version": "1.8.25p1",
+        "release": "4.el8_0.3",
+        "build_id": 1234,
+    }
+
+    fake_koji.build_data[1234] = {
+        "id": 1234,
+        "name": "sudo",
+        "version": "1.8.25p1",
+        "release": "4.el8_0.3",
+        "nvr": "sudo-1.8.25p1-4.el8_0.3",
+    }
+    fake_koji.build_data["sudo-1.8.25p1-4.el8_0.3"] = fake_koji.build_data[1234]
+
+    signed_rpm_path = os.path.join(
+        koji_dir,
+        "vol/somevol/packages/foobuild/1.0/1.el8",
+        "data/signed/def456/x86_64/foo-1.0-1.x86_64.rpm",
+    )
+
+    # Make signed RPMs exist (contents not relevant here)
+    for filename, rpm in fake_koji.rpm_data.items():
+        signed_rpm_path = os.path.join(
+            koji_dir,
+            "packages/sudo/1.8.25p1/4.el8_0.3/",
+            "data/signed/fd431d51/%s/%s" % (rpm["arch"], filename),
+        )
+        signed_dir = os.path.dirname(signed_rpm_path)
+        if not os.path.exists(signed_dir):
+            os.makedirs(signed_dir)
+        open(signed_rpm_path, "w")
+
+    yield source_ctor
+
+
+@pytest.mark.parametrize(
+    "rpm_filter_arch,expected_filenames",
+    [
+        (
+            "ppc64le",
+            [
+                "sudo-1.8.25p1-4.el8_0.3.ppc64le.rpm",
+                "sudo-debuginfo-1.8.25p1-4.el8_0.3.ppc64le.rpm",
+                "sudo-debugsource-1.8.25p1-4.el8_0.3.ppc64le.rpm",
+            ],
+        ),
+        (
+            # Checks amd64 => x86_64 conversion
+            "ppc64le,amd64",
+            [
+                "sudo-1.8.25p1-4.el8_0.3.ppc64le.rpm",
+                "sudo-1.8.25p1-4.el8_0.3.x86_64.rpm",
+                "sudo-debuginfo-1.8.25p1-4.el8_0.3.x86_64.rpm",
+                "sudo-debuginfo-1.8.25p1-4.el8_0.3.ppc64le.rpm",
+                "sudo-debugsource-1.8.25p1-4.el8_0.3.ppc64le.rpm",
+                "sudo-debugsource-1.8.25p1-4.el8_0.3.x86_64.rpm",
+            ],
+        ),
+        (
+            # Proper lists also work
+            ["x86_64", "SRPM"],
+            [
+                "sudo-1.8.25p1-4.el8_0.3.src.rpm",
+                "sudo-1.8.25p1-4.el8_0.3.x86_64.rpm",
+                "sudo-debuginfo-1.8.25p1-4.el8_0.3.x86_64.rpm",
+                "sudo-debugsource-1.8.25p1-4.el8_0.3.x86_64.rpm",
+            ],
+        ),
+        (
+            # Empty filter also works and gives nothing
+            [],
+            [],
+        ),
+    ],
+)
+def test_errata_rpms_filtered_by_arch(
+    source_factory, rpm_filter_arch, expected_filenames
+):
+    """Errata source can filter produced RPMs by arch"""
+
+    source = source_factory(rpm_filter_arch=rpm_filter_arch)
+
+    items = list(source)
+    rpm_items = [i for i in items if isinstance(i, RpmPushItem)]
+    filenames = sorted([i.name for i in rpm_items])
+    assert filenames == sorted(expected_filenames)


### PR DESCRIPTION
Add a parameter which allows adjusting the set of arches included in
returned RPMs.

The primary use-case for this at the moment is during alt-src pushes.
In that case, we know that only source RPMs are of interest, and
querying for other RPM arches only costs extra time.