### PR TITLE
Introduce separate class for modulemd sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `module_build` attribute to RPM push items.
 - Added `rpm_filter_arch` parameter to errata source, to select a subset of RPMs
   by architecture.
+- Added `ModuleMdSourcePushItem` class. Source modulemd documents are now represented
+  by this class rather than `ModuleMdPushItem`.
 
 ## [2.7.0] - 2021-06-10
 

--- a/src/pushsource/__init__.py
+++ b/src/pushsource/__init__.py
@@ -4,6 +4,7 @@ from pushsource._impl.model import (
     FilePushItem,
     CompsXmlPushItem,
     ModuleMdPushItem,
+    ModuleMdSourcePushItem,
     ProductIdPushItem,
     RpmPushItem,
     AmiPushItem,

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -12,7 +12,7 @@ from more_executors import Executors
 from more_executors.futures import f_map
 
 from ..source import Source
-from ..model import RpmPushItem, ModuleMdPushItem
+from ..model import RpmPushItem, ModuleMdPushItem, ModuleMdSourcePushItem
 from ..helpers import list_argument, try_int
 from .modulemd import Module
 
@@ -333,10 +333,12 @@ class KojiSource(Source):
 
             name = self._get_module_name(nvr, file_path)
 
+            klass = ModuleMdPushItem
+            if os.path.basename(file_path) == "modulemd.src.txt":
+                klass = ModuleMdSourcePushItem
+
             out.append(
-                ModuleMdPushItem(
-                    name=name, src=file_path, dest=self._dest, build=meta["nvr"]
-                )
+                klass(name=name, src=file_path, dest=self._dest, build=meta["nvr"])
             )
         return out
 

--- a/src/pushsource/_impl/model/__init__.py
+++ b/src/pushsource/_impl/model/__init__.py
@@ -8,7 +8,7 @@ from .erratum import (
 )
 from .rpm import RpmPushItem
 from .file import FilePushItem
-from .modulemd import ModuleMdPushItem
+from .modulemd import ModuleMdPushItem, ModuleMdSourcePushItem
 from .comps import CompsXmlPushItem
 from .productid import ProductIdPushItem
 from .ami import AmiPushItem, AmiRelease, AmiBillingCodes

--- a/src/pushsource/_impl/model/modulemd.py
+++ b/src/pushsource/_impl/model/modulemd.py
@@ -13,3 +13,15 @@ class ModuleMdPushItem(PushItem):
     This library does not verify that the referenced file is a valid
     modulemd stream.
     """
+
+
+@attr.s()
+class ModuleMdSourcePushItem(PushItem):
+    """A :class:`~pushsource.PushItem` representing a modulemd source/packager document.
+
+    Similar to :class:`~pushsource.ModuleMdPushItem`, but refers to the source
+    document, typically named ``modulemd.src.txt`` in koji.
+
+    This library does not verify that the referenced file is a valid
+    modulemd source document.
+    """

--- a/tests/koji/test_koji_module.py
+++ b/tests/koji/test_koji_module.py
@@ -5,7 +5,7 @@ import textwrap
 from pytest import raises, fixture
 from mock import patch
 
-from pushsource import Source, ModuleMdPushItem
+from pushsource import Source, ModuleMdPushItem, ModuleMdSourcePushItem
 
 from .fake_koji import FakeKojiController
 
@@ -57,7 +57,7 @@ def test_koji_modules(fake_koji, koji_dir):
         signing_key=None,
     )
 
-    assert items[1] == ModuleMdPushItem(
+    assert items[1] == ModuleMdSourcePushItem(
         # For this module, no attempt was made to parse it since it's a modulemd
         # source file rather than a built module.
         name="modulemd.src.txt",


### PR DESCRIPTION
We had previously used ModuleMdPushItem to represent any
modulemd-related archives on a koji build. This included both built
modules such as modulemd.x86_64.txt and module source files such as
modulemd.src.txt.

We shouldn't really do that though, because they're very different
things. The document format is not the same, and the expected usage of
each type of push item is completely different (e.g. modulemd.src.txt
are not meant to be uploaded to yum repos).

Let's model them as separate types so the caller can process the two
types differently and won't accidentally try to handle a source modulemd
in the same way as a built modulemd.