### PR TITLE
docs: add an attribute index onto push items

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx.ext.viewcode",
     # own extensions in 'ext' dir
     "attr_types",
+    "attr_index",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/ext/attr_index.py
+++ b/docs/ext/attr_index.py
@@ -1,0 +1,65 @@
+# An extension to add an index of attributes within class docs.
+#
+# For classes using attrs, this will produce a list under the class description
+# of the form:
+#
+#  Attributes:
+#    - base-attr [inherited]
+#    - other-base-attr [inherited]
+#    - my-own-attr
+#    - my-other-attr
+#    - (...etc)
+#
+# The motivation is to make it easier to navigate around our quite large set
+# of attributes and also to improve visibility of inherited attributes on
+# subclasses (without duplicating their entire doc strings).
+#
+# In principle it works on all attrs-using classes, but is primarily of use
+# for PushItem subclasses.
+
+
+def find_owning_class(klass, attr_name):
+    # Given an attribute name and a class on which it was found, return
+    # the class which owns that attribute (as opposed to inheriting it)
+    for candidate in klass.__mro__:
+        if not hasattr(candidate, "__attrs_attrs__"):
+            continue
+
+        attr = getattr(candidate.__attrs_attrs__, attr_name)
+        if not attr.inherited:
+            # It belongs here
+            return candidate
+
+
+def add_attr_index(app, what, name, obj, options, lines):
+    if not hasattr(obj, "__attrs_attrs__"):
+        return
+
+    attrs = sorted(
+        obj.__attrs_attrs__, key=lambda attr: (not attr.inherited, attr.name)
+    )
+    if not attrs:
+        return
+
+    # We've got some attributes. Let's produce an index of them, linking to both
+    # the inherited and local attributes.
+
+    lines.extend(["", "**Attributes:**", ""])
+    for attr in attrs:
+        if attr.inherited:
+            klass = find_owning_class(obj, attr.name)
+            if klass:
+                line = "* :meth:`~pushsource.%s.%s` *[inherited]*" % (
+                    klass.__name__,
+                    attr.name,
+                )
+        else:
+            line = "* :meth:`%s`" % attr.name
+
+        lines.append(line)
+    lines.extend(["", ""])
+
+
+def setup(app):
+    # entrypoint invoked by sphinx when extension is loaded
+    app.connect("autodoc-process-docstring", add_attr_index)


### PR DESCRIPTION
Previously, in the docs for push item classes, inherited attributes
were not displayed. This is annoying since it means one needs to look at
the base class and subclass docs together to understand what's
available. In extreme cases such as ProductIdPushItem which don't have
any of their own attributes, it gives the impression of a completely
empty class.

Unfortunately none of the built-in sphinx autodoc features seem able to
solve this.  There is an :inherited-members: option, but if enabled it
copies the entire doc strings from the base classes without any
indication of what's inherited and what's not, which is far too
verbose.

So let's add a little extension ourselves which generates a list under
the class description.