### PR TITLE
tests: extend koji dump util with more fields

### DIFF
--- a/tests/koji/data/builds/cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
+++ b/tests/koji/data/builds/cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
@@ -4,6 +4,44 @@
 archives:
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            License: GPLv2+
+            architecture: arm64
+            build-date: '2020-07-07T07:51:04.766067'
+            com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: cluster-logging-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift Container Platform that
+              manages the lifecycle of the Aggregated logging stack.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift Container Platform
+              that manages the lifecycle of the Aggregated logging stack.
+            io.k8s.display-name: Cluster Logging Operator
+            io.openshift.build.commit.id: 1768a1e54769995ac4a3e2f1bcd40f6549302326
+            io.openshift.build.commit.url: https://github.com/openshift/cluster-logging-operator/commit/1768a1e54769995ac4a3e2f1bcd40f6549302326
+            io.openshift.build.source-location: https://github.com/openshift/cluster-logging-operator
+            io.openshift.maintainer.component: Logging
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift,logging
+            maintainer: AOS Logging <aos-logging@redhat.com>
+            name: openshift/ose-cluster-logging-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-cluster-logging-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: db86b4b58c72bfe5067131461caeaf53b48812a0
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:759da12e95ff57da1e0c83ee534f78a2292b79c1bf288e40ff1cb256d42440a7
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-logging-operator-metadata:rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-logging-operator-metadata@sha256:759da12e95ff57da1e0c83ee534f78a2292b79c1bf288e40ff1cb256d42440a7
+      tags:
+      - rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
     image:
       arch: aarch64
   filename: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
@@ -16,6 +54,44 @@ archives:
   type_name: zip
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            License: GPLv2+
+            architecture: x86_64
+            build-date: '2020-07-07T07:51:01.831686'
+            com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+            com.redhat.component: cluster-logging-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift Container Platform that
+              manages the lifecycle of the Aggregated logging stack.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift Container Platform
+              that manages the lifecycle of the Aggregated logging stack.
+            io.k8s.display-name: Cluster Logging Operator
+            io.openshift.build.commit.id: 1768a1e54769995ac4a3e2f1bcd40f6549302326
+            io.openshift.build.commit.url: https://github.com/openshift/cluster-logging-operator/commit/1768a1e54769995ac4a3e2f1bcd40f6549302326
+            io.openshift.build.source-location: https://github.com/openshift/cluster-logging-operator
+            io.openshift.maintainer.component: Logging
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift,logging
+            maintainer: AOS Logging <aos-logging@redhat.com>
+            name: openshift/ose-cluster-logging-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-cluster-logging-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: db86b4b58c72bfe5067131461caeaf53b48812a0
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:f5453808b4231f2b1e3121c8d302ed755475a76154ae353b49381966830c9a18
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-logging-operator-metadata:rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-logging-operator-metadata@sha256:f5453808b4231f2b1e3121c8d302ed755475a76154ae353b49381966830c9a18
+      tags:
+      - rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
     image:
       arch: x86_64
   filename: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
@@ -23,6 +99,44 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            License: GPLv2+
+            architecture: s390x
+            build-date: '2020-07-07T07:51:03.575557'
+            com.redhat.build-host: s390-c1-vm-03.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: cluster-logging-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift Container Platform that
+              manages the lifecycle of the Aggregated logging stack.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift Container Platform
+              that manages the lifecycle of the Aggregated logging stack.
+            io.k8s.display-name: Cluster Logging Operator
+            io.openshift.build.commit.id: 1768a1e54769995ac4a3e2f1bcd40f6549302326
+            io.openshift.build.commit.url: https://github.com/openshift/cluster-logging-operator/commit/1768a1e54769995ac4a3e2f1bcd40f6549302326
+            io.openshift.build.source-location: https://github.com/openshift/cluster-logging-operator
+            io.openshift.maintainer.component: Logging
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift,logging
+            maintainer: AOS Logging <aos-logging@redhat.com>
+            name: openshift/ose-cluster-logging-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-cluster-logging-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: db86b4b58c72bfe5067131461caeaf53b48812a0
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:5748c3cfdc9c493f1538d55137a84c25560e4344f097314d9e12b838c0bba189
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-logging-operator-metadata:rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-logging-operator-metadata@sha256:5748c3cfdc9c493f1538d55137a84c25560e4344f097314d9e12b838c0bba189
+      tags:
+      - rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
     image:
       arch: s390x
   filename: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
@@ -30,6 +144,44 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            License: GPLv2+
+            architecture: ppc64le
+            build-date: '2020-07-07T07:51:05.153325'
+            com.redhat.build-host: ppc64le-c1-vm-06.prod.osbs.eng.rdu2.redhat.com
+            com.redhat.component: cluster-logging-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift Container Platform that
+              manages the lifecycle of the Aggregated logging stack.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift Container Platform
+              that manages the lifecycle of the Aggregated logging stack.
+            io.k8s.display-name: Cluster Logging Operator
+            io.openshift.build.commit.id: 1768a1e54769995ac4a3e2f1bcd40f6549302326
+            io.openshift.build.commit.url: https://github.com/openshift/cluster-logging-operator/commit/1768a1e54769995ac4a3e2f1bcd40f6549302326
+            io.openshift.build.source-location: https://github.com/openshift/cluster-logging-operator
+            io.openshift.maintainer.component: Logging
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift,logging
+            maintainer: AOS Logging <aos-logging@redhat.com>
+            name: openshift/ose-cluster-logging-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-cluster-logging-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: db86b4b58c72bfe5067131461caeaf53b48812a0
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:a279d2c29442bfa73550c428c30b058632e0656502ace41f7fffb8c44ed5b9fe
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-logging-operator-metadata:rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-logging-operator-metadata@sha256:a279d2c29442bfa73550c428c30b058632e0656502ace41f7fffb8c44ed5b9fe
+      tags:
+      - rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
     image:
       arch: ppc64le
   filename: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz

--- a/tests/koji/data/builds/cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
+++ b/tests/koji/data/builds/cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
@@ -4,6 +4,42 @@
 archives:
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: arm64
+            build-date: '2020-07-07T07:59:28.720837'
+            com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: cluster-nfd-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift and manages the node feature
+              discovery.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift and manages the node
+              feature discovery.
+            io.k8s.display-name: OpenShift cluster-nfd-operator
+            io.openshift.build.commit.id: af8ffe7fcef786a239e9eabf7f9ffe24a0ee40f0
+            io.openshift.build.commit.url: https://github.com/openshift/cluster-nfd-operator/commit/af8ffe7fcef786a239e9eabf7f9ffe24a0ee40f0
+            io.openshift.build.source-location: https://github.com/openshift/cluster-nfd-operator
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift
+            maintainer: ATS Auto Tuning Scalability  <aos-scalability@redhat.com>
+            name: openshift/ose-cluster-nfd-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-cluster-nfd-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: a2e6bed488f1b0c6e729551eea47b38dfaa31640
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:edf7feb928d85e0b8d2c64bdcd893c9a149f6767beb10579a051714b9e7c2503
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-nfd-operator-metadata:rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-nfd-operator-metadata@sha256:edf7feb928d85e0b8d2c64bdcd893c9a149f6767beb10579a051714b9e7c2503
+      tags:
+      - rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
     image:
       arch: aarch64
   filename: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
@@ -16,6 +52,42 @@ archives:
   type_name: zip
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: x86_64
+            build-date: '2020-07-07T07:59:26.115037'
+            com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+            com.redhat.component: cluster-nfd-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift and manages the node feature
+              discovery.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift and manages the node
+              feature discovery.
+            io.k8s.display-name: OpenShift cluster-nfd-operator
+            io.openshift.build.commit.id: af8ffe7fcef786a239e9eabf7f9ffe24a0ee40f0
+            io.openshift.build.commit.url: https://github.com/openshift/cluster-nfd-operator/commit/af8ffe7fcef786a239e9eabf7f9ffe24a0ee40f0
+            io.openshift.build.source-location: https://github.com/openshift/cluster-nfd-operator
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift
+            maintainer: ATS Auto Tuning Scalability  <aos-scalability@redhat.com>
+            name: openshift/ose-cluster-nfd-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-cluster-nfd-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: a2e6bed488f1b0c6e729551eea47b38dfaa31640
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:64e2392a10efacb98ab79db839babe4031f6ff94f832c7ab5ca52d1d6e124ea6
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-nfd-operator-metadata:rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-nfd-operator-metadata@sha256:64e2392a10efacb98ab79db839babe4031f6ff94f832c7ab5ca52d1d6e124ea6
+      tags:
+      - rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
     image:
       arch: x86_64
   filename: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
@@ -23,6 +95,42 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: s390x
+            build-date: '2020-07-07T07:59:26.516984'
+            com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: cluster-nfd-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift and manages the node feature
+              discovery.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift and manages the node
+              feature discovery.
+            io.k8s.display-name: OpenShift cluster-nfd-operator
+            io.openshift.build.commit.id: af8ffe7fcef786a239e9eabf7f9ffe24a0ee40f0
+            io.openshift.build.commit.url: https://github.com/openshift/cluster-nfd-operator/commit/af8ffe7fcef786a239e9eabf7f9ffe24a0ee40f0
+            io.openshift.build.source-location: https://github.com/openshift/cluster-nfd-operator
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift
+            maintainer: ATS Auto Tuning Scalability  <aos-scalability@redhat.com>
+            name: openshift/ose-cluster-nfd-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-cluster-nfd-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: a2e6bed488f1b0c6e729551eea47b38dfaa31640
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:7d24896df49bf8969d9e92b177ca44dce42dc8878f4a8bb4073e1a245e6e8b24
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-nfd-operator-metadata:rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-nfd-operator-metadata@sha256:7d24896df49bf8969d9e92b177ca44dce42dc8878f4a8bb4073e1a245e6e8b24
+      tags:
+      - rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
     image:
       arch: s390x
   filename: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
@@ -30,6 +138,42 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: ppc64le
+            build-date: '2020-07-07T07:59:29.047233'
+            com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+            com.redhat.component: cluster-nfd-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift and manages the node feature
+              discovery.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift and manages the node
+              feature discovery.
+            io.k8s.display-name: OpenShift cluster-nfd-operator
+            io.openshift.build.commit.id: af8ffe7fcef786a239e9eabf7f9ffe24a0ee40f0
+            io.openshift.build.commit.url: https://github.com/openshift/cluster-nfd-operator/commit/af8ffe7fcef786a239e9eabf7f9ffe24a0ee40f0
+            io.openshift.build.source-location: https://github.com/openshift/cluster-nfd-operator
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift
+            maintainer: ATS Auto Tuning Scalability  <aos-scalability@redhat.com>
+            name: openshift/ose-cluster-nfd-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-cluster-nfd-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: a2e6bed488f1b0c6e729551eea47b38dfaa31640
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:76c416c5dd128cb95f84c5ae277dd954bee390b2ad2e77d295aa01af5cf3b203
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-nfd-operator-metadata:rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-nfd-operator-metadata@sha256:76c416c5dd128cb95f84c5ae277dd954bee390b2ad2e77d295aa01af5cf3b203
+      tags:
+      - rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
     image:
       arch: ppc64le
   filename: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz

--- a/tests/koji/data/builds/elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
+++ b/tests/koji/data/builds/elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
@@ -4,6 +4,43 @@
 archives:
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: arm64
+            build-date: '2020-07-07T07:52:34.965108'
+            com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: elasticsearch-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is the component that manages an Elasticsearch cluster
+              on a kubernetes based platform
+            distribution-scope: public
+            io.k8s.description: This is the component that manages an Elasticsearch
+              cluster on a kubernetes based platform
+            io.k8s.display-name: OpenShift elasticsearch-operator
+            io.openshift.build.commit.id: 5b19ebc2a52a06b03fbe00b2fa6da8182295fcdd
+            io.openshift.build.commit.url: https://github.com/openshift/elasticsearch-operator/commit/5b19ebc2a52a06b03fbe00b2fa6da8182295fcdd
+            io.openshift.build.source-location: https://github.com/openshift/elasticsearch-operator
+            io.openshift.maintainer.component: Logging
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift,logging,elasticsearch
+            maintainer: AOS Logging <aos-logging@redhat.com>
+            name: openshift/ose-elasticsearch-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-elasticsearch-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: c97d0d822e7518844733a557a3871dc7ba6e9e56
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:ec9a928f3a413a311ebbce5b718e42af2880cac31887be824cb7f37c224c69d0
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-elasticsearch-operator-metadata:rhaos-4.3-rhel-7-candidate-50417-20200707075226-aarch64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-elasticsearch-operator-metadata@sha256:ec9a928f3a413a311ebbce5b718e42af2880cac31887be824cb7f37c224c69d0
+      tags:
+      - rhaos-4.3-rhel-7-candidate-50417-20200707075226-aarch64
     image:
       arch: aarch64
   filename: docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
@@ -16,6 +53,43 @@ archives:
   type_name: zip
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: x86_64
+            build-date: '2020-07-07T07:52:32.204087'
+            com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+            com.redhat.component: elasticsearch-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is the component that manages an Elasticsearch cluster
+              on a kubernetes based platform
+            distribution-scope: public
+            io.k8s.description: This is the component that manages an Elasticsearch
+              cluster on a kubernetes based platform
+            io.k8s.display-name: OpenShift elasticsearch-operator
+            io.openshift.build.commit.id: 5b19ebc2a52a06b03fbe00b2fa6da8182295fcdd
+            io.openshift.build.commit.url: https://github.com/openshift/elasticsearch-operator/commit/5b19ebc2a52a06b03fbe00b2fa6da8182295fcdd
+            io.openshift.build.source-location: https://github.com/openshift/elasticsearch-operator
+            io.openshift.maintainer.component: Logging
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift,logging,elasticsearch
+            maintainer: AOS Logging <aos-logging@redhat.com>
+            name: openshift/ose-elasticsearch-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-elasticsearch-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: c97d0d822e7518844733a557a3871dc7ba6e9e56
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:f205a649e55b8757792a4d96ca5cfdadf6d717a11916fb47abb6fae623ff9e10
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-elasticsearch-operator-metadata:rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-elasticsearch-operator-metadata@sha256:f205a649e55b8757792a4d96ca5cfdadf6d717a11916fb47abb6fae623ff9e10
+      tags:
+      - rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
     image:
       arch: x86_64
   filename: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
@@ -23,6 +97,43 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: s390x
+            build-date: '2020-07-07T07:52:32.294701'
+            com.redhat.build-host: s390-c1-vm-02.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: elasticsearch-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is the component that manages an Elasticsearch cluster
+              on a kubernetes based platform
+            distribution-scope: public
+            io.k8s.description: This is the component that manages an Elasticsearch
+              cluster on a kubernetes based platform
+            io.k8s.display-name: OpenShift elasticsearch-operator
+            io.openshift.build.commit.id: 5b19ebc2a52a06b03fbe00b2fa6da8182295fcdd
+            io.openshift.build.commit.url: https://github.com/openshift/elasticsearch-operator/commit/5b19ebc2a52a06b03fbe00b2fa6da8182295fcdd
+            io.openshift.build.source-location: https://github.com/openshift/elasticsearch-operator
+            io.openshift.maintainer.component: Logging
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift,logging,elasticsearch
+            maintainer: AOS Logging <aos-logging@redhat.com>
+            name: openshift/ose-elasticsearch-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-elasticsearch-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: c97d0d822e7518844733a557a3871dc7ba6e9e56
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:d6d01ef696e32c0a6a177c6098550e3583208841462489669006700e33da1fe7
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-elasticsearch-operator-metadata:rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-elasticsearch-operator-metadata@sha256:d6d01ef696e32c0a6a177c6098550e3583208841462489669006700e33da1fe7
+      tags:
+      - rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
     image:
       arch: s390x
   filename: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
@@ -30,6 +141,43 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: ppc64le
+            build-date: '2020-07-07T07:52:35.177144'
+            com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
+            com.redhat.component: elasticsearch-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is the component that manages an Elasticsearch cluster
+              on a kubernetes based platform
+            distribution-scope: public
+            io.k8s.description: This is the component that manages an Elasticsearch
+              cluster on a kubernetes based platform
+            io.k8s.display-name: OpenShift elasticsearch-operator
+            io.openshift.build.commit.id: 5b19ebc2a52a06b03fbe00b2fa6da8182295fcdd
+            io.openshift.build.commit.url: https://github.com/openshift/elasticsearch-operator/commit/5b19ebc2a52a06b03fbe00b2fa6da8182295fcdd
+            io.openshift.build.source-location: https://github.com/openshift/elasticsearch-operator
+            io.openshift.maintainer.component: Logging
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift,logging,elasticsearch
+            maintainer: AOS Logging <aos-logging@redhat.com>
+            name: openshift/ose-elasticsearch-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-elasticsearch-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: c97d0d822e7518844733a557a3871dc7ba6e9e56
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:8f9bc568515b7ae3d8ca4e9e5db9e8001070d77f45e41af78f7ec4fc29545c60
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-elasticsearch-operator-metadata:rhaos-4.3-rhel-7-candidate-80524-20200707075228-ppc64le
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-elasticsearch-operator-metadata@sha256:8f9bc568515b7ae3d8ca4e9e5db9e8001070d77f45e41af78f7ec4fc29545c60
+      tags:
+      - rhaos-4.3-rhel-7-candidate-80524-20200707075228-ppc64le
     image:
       arch: ppc64le
   filename: docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz

--- a/tests/koji/data/builds/local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
+++ b/tests/koji/data/builds/local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
@@ -4,6 +4,41 @@
 archives:
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: arm64
+            build-date: '2020-07-07T07:25:56.863331'
+            com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: local-storage-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift and manages local volumes.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift and manages local
+              volumes.
+            io.k8s.display-name: OpenShift local-storage-operator
+            io.openshift.build.commit.id: 0aa47439b66de12f1ee0c80aefa65e7f9076e952
+            io.openshift.build.commit.url: https://github.com/openshift/local-storage-operator/commit/0aa47439b66de12f1ee0c80aefa65e7f9076e952
+            io.openshift.build.source-location: https://github.com/openshift/local-storage-operator
+            io.openshift.maintainer.component: Storage
+            io.openshift.maintainer.product: OpenShift Container Platform
+            maintainer: Hemant Kumar <hekumar@redhat.com>
+            name: openshift/ose-local-storage-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-local-storage-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: ecd0eece5d31e4ebbf6a0f47c637decd189ef7dc
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:30f197a9de12601460d006e1f8b33e66fe355a46de75cf11c959df8bfc9bdaaa
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-local-storage-operator-metadata:rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-local-storage-operator-metadata@sha256:30f197a9de12601460d006e1f8b33e66fe355a46de75cf11c959df8bfc9bdaaa
+      tags:
+      - rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
     image:
       arch: aarch64
   filename: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
@@ -16,6 +51,41 @@ archives:
   type_name: zip
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: x86_64
+            build-date: '2020-07-07T07:25:53.177018'
+            com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+            com.redhat.component: local-storage-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift and manages local volumes.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift and manages local
+              volumes.
+            io.k8s.display-name: OpenShift local-storage-operator
+            io.openshift.build.commit.id: 0aa47439b66de12f1ee0c80aefa65e7f9076e952
+            io.openshift.build.commit.url: https://github.com/openshift/local-storage-operator/commit/0aa47439b66de12f1ee0c80aefa65e7f9076e952
+            io.openshift.build.source-location: https://github.com/openshift/local-storage-operator
+            io.openshift.maintainer.component: Storage
+            io.openshift.maintainer.product: OpenShift Container Platform
+            maintainer: Hemant Kumar <hekumar@redhat.com>
+            name: openshift/ose-local-storage-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-local-storage-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: ecd0eece5d31e4ebbf6a0f47c637decd189ef7dc
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:482031ade5610ae584e5c75f844ad8139b4b18a6b7525a29517f5e4cbaf1646b
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-local-storage-operator-metadata:rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-local-storage-operator-metadata@sha256:482031ade5610ae584e5c75f844ad8139b4b18a6b7525a29517f5e4cbaf1646b
+      tags:
+      - rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
     image:
       arch: x86_64
   filename: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
@@ -23,6 +93,41 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: s390x
+            build-date: '2020-07-07T07:25:54.573065'
+            com.redhat.build-host: s390-c2-vm-03.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: local-storage-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift and manages local volumes.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift and manages local
+              volumes.
+            io.k8s.display-name: OpenShift local-storage-operator
+            io.openshift.build.commit.id: 0aa47439b66de12f1ee0c80aefa65e7f9076e952
+            io.openshift.build.commit.url: https://github.com/openshift/local-storage-operator/commit/0aa47439b66de12f1ee0c80aefa65e7f9076e952
+            io.openshift.build.source-location: https://github.com/openshift/local-storage-operator
+            io.openshift.maintainer.component: Storage
+            io.openshift.maintainer.product: OpenShift Container Platform
+            maintainer: Hemant Kumar <hekumar@redhat.com>
+            name: openshift/ose-local-storage-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-local-storage-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: ecd0eece5d31e4ebbf6a0f47c637decd189ef7dc
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:53fb41caedbff04e8ed8b7fab5ec761214c0578303080820223d54282ea95f5a
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-local-storage-operator-metadata:rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-local-storage-operator-metadata@sha256:53fb41caedbff04e8ed8b7fab5ec761214c0578303080820223d54282ea95f5a
+      tags:
+      - rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
     image:
       arch: s390x
   filename: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
@@ -30,6 +135,41 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: ppc64le
+            build-date: '2020-07-07T07:25:57.478498'
+            com.redhat.build-host: ppc64le-c2-vm-03.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: local-storage-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift and manages local volumes.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift and manages local
+              volumes.
+            io.k8s.display-name: OpenShift local-storage-operator
+            io.openshift.build.commit.id: 0aa47439b66de12f1ee0c80aefa65e7f9076e952
+            io.openshift.build.commit.url: https://github.com/openshift/local-storage-operator/commit/0aa47439b66de12f1ee0c80aefa65e7f9076e952
+            io.openshift.build.source-location: https://github.com/openshift/local-storage-operator
+            io.openshift.maintainer.component: Storage
+            io.openshift.maintainer.product: OpenShift Container Platform
+            maintainer: Hemant Kumar <hekumar@redhat.com>
+            name: openshift/ose-local-storage-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-local-storage-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: ecd0eece5d31e4ebbf6a0f47c637decd189ef7dc
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:4e3e4ece862f9bb5ff473efb637c47ebb4916d5925270495583f86d19d22bbf8
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-local-storage-operator-metadata:rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-local-storage-operator-metadata@sha256:4e3e4ece862f9bb5ff473efb637c47ebb4916d5925270495583f86d19d22bbf8
+      tags:
+      - rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
     image:
       arch: ppc64le
   filename: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz

--- a/tests/koji/data/builds/openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
+++ b/tests/koji/data/builds/openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
@@ -4,6 +4,35 @@
 archives:
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: arm64
+            build-date: '2020-07-07T08:04:51.951124'
+            com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            distribution-scope: public
+            io.openshift.build.commit.id: dd617fb0a0511f9046db4cd290999a87170720c6
+            io.openshift.build.commit.url: https://github.com/openshift/ansible-service-broker/commit/dd617fb0a0511f9046db4cd290999a87170720c6
+            io.openshift.build.source-location: https://github.com/openshift/ansible-service-broker
+            io.openshift.maintainer.product: OpenShift Container Platform
+            name: openshift/ose-openshift-enterprise-ansible-service-broker-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-openshift-enterprise-ansible-service-broker-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 1785aefc1c5f30ef0051420f80d68218d01aaaa1
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:34d3a33bd01cffac254244db11d1112c675415779ca147be90ae7a3714f04139
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-ansible-service-broker-operator-metadata:rhaos-4.3-rhel-7-candidate-46533-20200707080442-aarch64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-ansible-service-broker-operator-metadata@sha256:34d3a33bd01cffac254244db11d1112c675415779ca147be90ae7a3714f04139
+      tags:
+      - rhaos-4.3-rhel-7-candidate-46533-20200707080442-aarch64
     image:
       arch: aarch64
   filename: docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
@@ -16,6 +45,35 @@ archives:
   type_name: zip
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: x86_64
+            build-date: '2020-07-07T08:04:47.567154'
+            com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+            com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            distribution-scope: public
+            io.openshift.build.commit.id: dd617fb0a0511f9046db4cd290999a87170720c6
+            io.openshift.build.commit.url: https://github.com/openshift/ansible-service-broker/commit/dd617fb0a0511f9046db4cd290999a87170720c6
+            io.openshift.build.source-location: https://github.com/openshift/ansible-service-broker
+            io.openshift.maintainer.product: OpenShift Container Platform
+            name: openshift/ose-openshift-enterprise-ansible-service-broker-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-openshift-enterprise-ansible-service-broker-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 1785aefc1c5f30ef0051420f80d68218d01aaaa1
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:9604788cd8993127146e7778e0105b32c3f8484c2329c2d616d02fa3c6ed60ca
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-ansible-service-broker-operator-metadata:rhaos-4.3-rhel-7-candidate-12704-20200707080441-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-ansible-service-broker-operator-metadata@sha256:9604788cd8993127146e7778e0105b32c3f8484c2329c2d616d02fa3c6ed60ca
+      tags:
+      - rhaos-4.3-rhel-7-candidate-12704-20200707080441-x86_64
     image:
       arch: x86_64
   filename: docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
@@ -23,6 +81,35 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: s390x
+            build-date: '2020-07-07T08:04:49.844782'
+            com.redhat.build-host: s390-c1-vm-04.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            distribution-scope: public
+            io.openshift.build.commit.id: dd617fb0a0511f9046db4cd290999a87170720c6
+            io.openshift.build.commit.url: https://github.com/openshift/ansible-service-broker/commit/dd617fb0a0511f9046db4cd290999a87170720c6
+            io.openshift.build.source-location: https://github.com/openshift/ansible-service-broker
+            io.openshift.maintainer.product: OpenShift Container Platform
+            name: openshift/ose-openshift-enterprise-ansible-service-broker-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-openshift-enterprise-ansible-service-broker-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 1785aefc1c5f30ef0051420f80d68218d01aaaa1
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:51d4206bb0f11900ca85b85401b6189713e4d98ebdf3f80ed803ecf455c88b50
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-ansible-service-broker-operator-metadata:rhaos-4.3-rhel-7-candidate-48676-20200707080442-s390x
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-ansible-service-broker-operator-metadata@sha256:51d4206bb0f11900ca85b85401b6189713e4d98ebdf3f80ed803ecf455c88b50
+      tags:
+      - rhaos-4.3-rhel-7-candidate-48676-20200707080442-s390x
     image:
       arch: s390x
   filename: docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
@@ -30,6 +117,35 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: ppc64le
+            build-date: '2020-07-07T08:04:51.445354'
+            com.redhat.build-host: ppc64le-c1-vm-02.prod.osbs.eng.rdu2.redhat.com
+            com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            distribution-scope: public
+            io.openshift.build.commit.id: dd617fb0a0511f9046db4cd290999a87170720c6
+            io.openshift.build.commit.url: https://github.com/openshift/ansible-service-broker/commit/dd617fb0a0511f9046db4cd290999a87170720c6
+            io.openshift.build.source-location: https://github.com/openshift/ansible-service-broker
+            io.openshift.maintainer.product: OpenShift Container Platform
+            name: openshift/ose-openshift-enterprise-ansible-service-broker-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-openshift-enterprise-ansible-service-broker-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 1785aefc1c5f30ef0051420f80d68218d01aaaa1
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:5dfb14191bfcd20d3e9d78bc66ebc58f0f6855da681aaf82fc52d4d77d9f0c7b
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-ansible-service-broker-operator-metadata:rhaos-4.3-rhel-7-candidate-13114-20200707080444-ppc64le
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-ansible-service-broker-operator-metadata@sha256:5dfb14191bfcd20d3e9d78bc66ebc58f0f6855da681aaf82fc52d4d77d9f0c7b
+      tags:
+      - rhaos-4.3-rhel-7-candidate-13114-20200707080444-ppc64le
     image:
       arch: ppc64le
   filename: docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz

--- a/tests/koji/data/builds/openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
+++ b/tests/koji/data/builds/openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
@@ -4,6 +4,36 @@
 archives:
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: arm64
+            build-date: '2020-07-07T07:57:06.447849'
+            com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            distribution-scope: public
+            io.openshift.build.commit.id: d583555f18f778fd1ac8472557165dba72f1ca24
+            io.openshift.build.commit.url: https://github.com/openshift/template-service-broker-operator/commit/d583555f18f778fd1ac8472557165dba72f1ca24
+            io.openshift.build.source-location: https://github.com/openshift/template-service-broker-operator
+            io.openshift.maintainer.component: Service Broker
+            io.openshift.maintainer.product: OpenShift Container Platform
+            name: openshift/ose-openshift-enterprise-template-service-broker-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-openshift-enterprise-template-service-broker-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 49667b44c040d42eb1e3aac9451a8e2ad9088098
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:332c4e13f2d0329d03fea2702b71070c2d4bbfe1f6753e6a963d0aa41a08086e
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata:rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata@sha256:332c4e13f2d0329d03fea2702b71070c2d4bbfe1f6753e6a963d0aa41a08086e
+      tags:
+      - rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
     image:
       arch: aarch64
   filename: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
@@ -16,6 +46,36 @@ archives:
   type_name: zip
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: x86_64
+            build-date: '2020-07-07T07:57:03.907272'
+            com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+            com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            distribution-scope: public
+            io.openshift.build.commit.id: d583555f18f778fd1ac8472557165dba72f1ca24
+            io.openshift.build.commit.url: https://github.com/openshift/template-service-broker-operator/commit/d583555f18f778fd1ac8472557165dba72f1ca24
+            io.openshift.build.source-location: https://github.com/openshift/template-service-broker-operator
+            io.openshift.maintainer.component: Service Broker
+            io.openshift.maintainer.product: OpenShift Container Platform
+            name: openshift/ose-openshift-enterprise-template-service-broker-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-openshift-enterprise-template-service-broker-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 49667b44c040d42eb1e3aac9451a8e2ad9088098
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:ea0ee5a340f99259c725dec0c2bafd10f569ffb8223db5c73d3f52e7df446058
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata:rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata@sha256:ea0ee5a340f99259c725dec0c2bafd10f569ffb8223db5c73d3f52e7df446058
+      tags:
+      - rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
     image:
       arch: x86_64
   filename: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
@@ -23,6 +83,36 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: s390x
+            build-date: '2020-07-07T07:57:05.506980'
+            com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            distribution-scope: public
+            io.openshift.build.commit.id: d583555f18f778fd1ac8472557165dba72f1ca24
+            io.openshift.build.commit.url: https://github.com/openshift/template-service-broker-operator/commit/d583555f18f778fd1ac8472557165dba72f1ca24
+            io.openshift.build.source-location: https://github.com/openshift/template-service-broker-operator
+            io.openshift.maintainer.component: Service Broker
+            io.openshift.maintainer.product: OpenShift Container Platform
+            name: openshift/ose-openshift-enterprise-template-service-broker-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-openshift-enterprise-template-service-broker-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 49667b44c040d42eb1e3aac9451a8e2ad9088098
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:f65555acb07c7e0c590389f55a16a395b9c7eb8071de2f0f32a273ea4d36fa03
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata:rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata@sha256:f65555acb07c7e0c590389f55a16a395b9c7eb8071de2f0f32a273ea4d36fa03
+      tags:
+      - rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
     image:
       arch: s390x
   filename: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
@@ -30,6 +120,36 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: ppc64le
+            build-date: '2020-07-07T07:57:07.365862'
+            com.redhat.build-host: ppc64le-c1-vm-04.prod.osbs.eng.rdu2.redhat.com
+            com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            distribution-scope: public
+            io.openshift.build.commit.id: d583555f18f778fd1ac8472557165dba72f1ca24
+            io.openshift.build.commit.url: https://github.com/openshift/template-service-broker-operator/commit/d583555f18f778fd1ac8472557165dba72f1ca24
+            io.openshift.build.source-location: https://github.com/openshift/template-service-broker-operator
+            io.openshift.maintainer.component: Service Broker
+            io.openshift.maintainer.product: OpenShift Container Platform
+            name: openshift/ose-openshift-enterprise-template-service-broker-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-openshift-enterprise-template-service-broker-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 49667b44c040d42eb1e3aac9451a8e2ad9088098
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:6d76d7291e57bf0236bd14ef6a786d4b5140553443172595a6a60a6b6b340a7e
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata:rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata@sha256:6d76d7291e57bf0236bd14ef6a786d4b5140553443172595a6a60a6b6b340a7e
+      tags:
+      - rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
     image:
       arch: ppc64le
   filename: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz

--- a/tests/koji/data/builds/ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
+++ b/tests/koji/data/builds/ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
@@ -4,6 +4,43 @@
 archives:
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: arm64
+            build-date: '2020-07-07T07:41:06.593215'
+            com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: ose-metering-ansible-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift Container Platform and manages
+              installation and configuration of all other metering components.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift Container Platform
+              and manages installation and configuration of all other metering components.
+            io.k8s.display-name: OpenShift metering-ansible-operator
+            io.openshift.build.commit.id: 44d9b0329bf6ef52049f122e4760ef4e66e72e52
+            io.openshift.build.commit.url: https://github.com/kube-reporting/metering-operator/commit/44d9b0329bf6ef52049f122e4760ef4e66e72e52
+            io.openshift.build.source-location: https://github.com/kube-reporting/metering-operator
+            io.openshift.maintainer.component: Metering Operator
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift
+            maintainer: Chance Zibolski <sd-operator-metering@redhat.com>
+            name: openshift/ose-ose-metering-ansible-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-ose-metering-ansible-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: f6e7624ae9bb5053d6654a5633c06368e391eac3
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:ba151c6f9fa29414b5aa0163fe4a2176c6eb6b9bbc32a98d27ece6fbb9fa00c0
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata:rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata@sha256:ba151c6f9fa29414b5aa0163fe4a2176c6eb6b9bbc32a98d27ece6fbb9fa00c0
+      tags:
+      - rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
     image:
       arch: aarch64
   filename: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
@@ -16,6 +53,43 @@ archives:
   type_name: zip
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: x86_64
+            build-date: '2020-07-07T07:41:03.230911'
+            com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+            com.redhat.component: ose-metering-ansible-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift Container Platform and manages
+              installation and configuration of all other metering components.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift Container Platform
+              and manages installation and configuration of all other metering components.
+            io.k8s.display-name: OpenShift metering-ansible-operator
+            io.openshift.build.commit.id: 44d9b0329bf6ef52049f122e4760ef4e66e72e52
+            io.openshift.build.commit.url: https://github.com/kube-reporting/metering-operator/commit/44d9b0329bf6ef52049f122e4760ef4e66e72e52
+            io.openshift.build.source-location: https://github.com/kube-reporting/metering-operator
+            io.openshift.maintainer.component: Metering Operator
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift
+            maintainer: Chance Zibolski <sd-operator-metering@redhat.com>
+            name: openshift/ose-ose-metering-ansible-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-ose-metering-ansible-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: f6e7624ae9bb5053d6654a5633c06368e391eac3
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:6818dad3b9da5bbc6b728f6f5590467fd34c37f3a1a5e2c9f3aabeef84fed12f
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata:rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata@sha256:6818dad3b9da5bbc6b728f6f5590467fd34c37f3a1a5e2c9f3aabeef84fed12f
+      tags:
+      - rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
     image:
       arch: x86_64
   filename: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
@@ -23,6 +97,43 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: s390x
+            build-date: '2020-07-07T07:41:04.122222'
+            com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: ose-metering-ansible-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift Container Platform and manages
+              installation and configuration of all other metering components.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift Container Platform
+              and manages installation and configuration of all other metering components.
+            io.k8s.display-name: OpenShift metering-ansible-operator
+            io.openshift.build.commit.id: 44d9b0329bf6ef52049f122e4760ef4e66e72e52
+            io.openshift.build.commit.url: https://github.com/kube-reporting/metering-operator/commit/44d9b0329bf6ef52049f122e4760ef4e66e72e52
+            io.openshift.build.source-location: https://github.com/kube-reporting/metering-operator
+            io.openshift.maintainer.component: Metering Operator
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift
+            maintainer: Chance Zibolski <sd-operator-metering@redhat.com>
+            name: openshift/ose-ose-metering-ansible-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-ose-metering-ansible-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: f6e7624ae9bb5053d6654a5633c06368e391eac3
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:92727964274c003c4e27f6f55ab3ebae2f96c7225511ece3061714f82368aa09
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata:rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata@sha256:92727964274c003c4e27f6f55ab3ebae2f96c7225511ece3061714f82368aa09
+      tags:
+      - rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
     image:
       arch: s390x
   filename: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
@@ -30,6 +141,43 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: ppc64le
+            build-date: '2020-07-07T07:41:06.666770'
+            com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+            com.redhat.component: ose-metering-ansible-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component of OpenShift Container Platform and manages
+              installation and configuration of all other metering components.
+            distribution-scope: public
+            io.k8s.description: This is a component of OpenShift Container Platform
+              and manages installation and configuration of all other metering components.
+            io.k8s.display-name: OpenShift metering-ansible-operator
+            io.openshift.build.commit.id: 44d9b0329bf6ef52049f122e4760ef4e66e72e52
+            io.openshift.build.commit.url: https://github.com/kube-reporting/metering-operator/commit/44d9b0329bf6ef52049f122e4760ef4e66e72e52
+            io.openshift.build.source-location: https://github.com/kube-reporting/metering-operator
+            io.openshift.maintainer.component: Metering Operator
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.tags: openshift
+            maintainer: Chance Zibolski <sd-operator-metering@redhat.com>
+            name: openshift/ose-ose-metering-ansible-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-ose-metering-ansible-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: f6e7624ae9bb5053d6654a5633c06368e391eac3
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:e010ea8e6a50e917a7884d971aafc06d783ae69fe7c40a372e7bc7acf7cf273b
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata:rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata@sha256:e010ea8e6a50e917a7884d971aafc06d783ae69fe7c40a372e7bc7acf7cf273b
+      tags:
+      - rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
     image:
       arch: ppc64le
   filename: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz

--- a/tests/koji/data/builds/ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
+++ b/tests/koji/data/builds/ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
@@ -4,6 +4,42 @@
 archives:
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: arm64
+            build-date: '2020-07-07T07:22:28.689715'
+            com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: ose-ptp-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component that manages cluster PTP configuration.
+            distribution-scope: public
+            io.k8s.description: This is a component that manages cluster PTP configuration.
+            io.k8s.display-name: OpenShift ptp-operator
+            io.openshift.build.commit.id: 32ac1984132a3da2b7015a06a8fe7ebac13c57e8
+            io.openshift.build.commit.url: https://github.com/openshift/ptp-operator/commit/32ac1984132a3da2b7015a06a8fe7ebac13c57e8
+            io.openshift.build.source-location: https://github.com/openshift/ptp-operator
+            io.openshift.maintainer.component: Networking
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.maintainer.subcomponent: ptp
+            io.openshift.tags: openshift,ptp
+            maintainer: Multus Team <multus-dev@redhat.com>
+            name: openshift/ose-ptp-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-ptp-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: b63ce47fbd3a5ec7851ad72015cf54d34033c117
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:a32a8dd76ccfe71632eb7bd30859512e9b517d5771f9e697f9e0c5d509cb4956
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ptp-operator-metadata:rhaos-4.3-rhel-7-candidate-76837-20200707072220-aarch64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ptp-operator-metadata@sha256:a32a8dd76ccfe71632eb7bd30859512e9b517d5771f9e697f9e0c5d509cb4956
+      tags:
+      - rhaos-4.3-rhel-7-candidate-76837-20200707072220-aarch64
     image:
       arch: aarch64
   filename: docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
@@ -16,6 +52,42 @@ archives:
   type_name: zip
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: x86_64
+            build-date: '2020-07-07T07:22:26.228066'
+            com.redhat.build-host: cpt-1008.osbs.prod.upshift.rdu2.redhat.com
+            com.redhat.component: ose-ptp-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component that manages cluster PTP configuration.
+            distribution-scope: public
+            io.k8s.description: This is a component that manages cluster PTP configuration.
+            io.k8s.display-name: OpenShift ptp-operator
+            io.openshift.build.commit.id: 32ac1984132a3da2b7015a06a8fe7ebac13c57e8
+            io.openshift.build.commit.url: https://github.com/openshift/ptp-operator/commit/32ac1984132a3da2b7015a06a8fe7ebac13c57e8
+            io.openshift.build.source-location: https://github.com/openshift/ptp-operator
+            io.openshift.maintainer.component: Networking
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.maintainer.subcomponent: ptp
+            io.openshift.tags: openshift,ptp
+            maintainer: Multus Team <multus-dev@redhat.com>
+            name: openshift/ose-ptp-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-ptp-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: b63ce47fbd3a5ec7851ad72015cf54d34033c117
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:a5d2edb02c21c769ed90593520511f954d9de63680e338bc457fc2289b9725a3
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ptp-operator-metadata:rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ptp-operator-metadata@sha256:a5d2edb02c21c769ed90593520511f954d9de63680e338bc457fc2289b9725a3
+      tags:
+      - rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
     image:
       arch: x86_64
   filename: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
@@ -23,6 +95,42 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: s390x
+            build-date: '2020-07-07T07:22:27.167128'
+            com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: ose-ptp-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component that manages cluster PTP configuration.
+            distribution-scope: public
+            io.k8s.description: This is a component that manages cluster PTP configuration.
+            io.k8s.display-name: OpenShift ptp-operator
+            io.openshift.build.commit.id: 32ac1984132a3da2b7015a06a8fe7ebac13c57e8
+            io.openshift.build.commit.url: https://github.com/openshift/ptp-operator/commit/32ac1984132a3da2b7015a06a8fe7ebac13c57e8
+            io.openshift.build.source-location: https://github.com/openshift/ptp-operator
+            io.openshift.maintainer.component: Networking
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.maintainer.subcomponent: ptp
+            io.openshift.tags: openshift,ptp
+            maintainer: Multus Team <multus-dev@redhat.com>
+            name: openshift/ose-ptp-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-ptp-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: b63ce47fbd3a5ec7851ad72015cf54d34033c117
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:f644b80c1a21401eb1fa79b6e2732db05818562850c6d9acb41413d4b1524847
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ptp-operator-metadata:rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ptp-operator-metadata@sha256:f644b80c1a21401eb1fa79b6e2732db05818562850c6d9acb41413d4b1524847
+      tags:
+      - rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
     image:
       arch: s390x
   filename: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
@@ -30,6 +138,42 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: ppc64le
+            build-date: '2020-07-07T07:22:29.434859'
+            com.redhat.build-host: ppc64le-c2-vm-02.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: ose-ptp-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is a component that manages cluster PTP configuration.
+            distribution-scope: public
+            io.k8s.description: This is a component that manages cluster PTP configuration.
+            io.k8s.display-name: OpenShift ptp-operator
+            io.openshift.build.commit.id: 32ac1984132a3da2b7015a06a8fe7ebac13c57e8
+            io.openshift.build.commit.url: https://github.com/openshift/ptp-operator/commit/32ac1984132a3da2b7015a06a8fe7ebac13c57e8
+            io.openshift.build.source-location: https://github.com/openshift/ptp-operator
+            io.openshift.maintainer.component: Networking
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.maintainer.subcomponent: ptp
+            io.openshift.tags: openshift,ptp
+            maintainer: Multus Team <multus-dev@redhat.com>
+            name: openshift/ose-ptp-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-ptp-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: b63ce47fbd3a5ec7851ad72015cf54d34033c117
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:d063d90f70fbfd210175023f564b1cfccebf52cda6fab7f9ab606e08a4095771
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ptp-operator-metadata:rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-ptp-operator-metadata@sha256:d063d90f70fbfd210175023f564b1cfccebf52cda6fab7f9ab606e08a4095771
+      tags:
+      - rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
     image:
       arch: ppc64le
   filename: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz

--- a/tests/koji/data/builds/sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
+++ b/tests/koji/data/builds/sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1.yaml
@@ -4,6 +4,44 @@
 archives:
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: arm64
+            build-date: '2020-07-07T07:32:49.830389'
+            com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: sriov-network-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is the component that manange and config sriov component
+              in Openshift cluster
+            distribution-scope: public
+            io.k8s.description: This is the component that manange and config sriov
+              component in Openshift cluster
+            io.k8s.display-name: OpenShift sriov-network-operator
+            io.openshift.build.commit.id: 0ab7429f9e91f50b5388268bf957f506118cbbd6
+            io.openshift.build.commit.url: https://github.com/openshift/sriov-network-operator/commit/0ab7429f9e91f50b5388268bf957f506118cbbd6
+            io.openshift.build.source-location: https://github.com/openshift/sriov-network-operator
+            io.openshift.maintainer.component: Networking
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.maintainer.subcomponent: SR-IOV
+            io.openshift.tags: openshift,networking,sr-iov
+            maintainer: Multus team <multus-dev@redhat.com>
+            name: openshift/ose-sriov-network-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-sriov-network-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 62f4332490eef03d61c2710baa3e17faae7aaa92
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:ab5ea2465f9d924c9f0e30a74ab57990dab383271c19dde33f35ec397be0386c
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-network-operator-metadata:rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-network-operator-metadata@sha256:ab5ea2465f9d924c9f0e30a74ab57990dab383271c19dde33f35ec397be0386c
+      tags:
+      - rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
     image:
       arch: aarch64
   filename: docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
@@ -16,6 +54,44 @@ archives:
   type_name: zip
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: x86_64
+            build-date: '2020-07-07T07:32:46.644503'
+            com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+            com.redhat.component: sriov-network-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is the component that manange and config sriov component
+              in Openshift cluster
+            distribution-scope: public
+            io.k8s.description: This is the component that manange and config sriov
+              component in Openshift cluster
+            io.k8s.display-name: OpenShift sriov-network-operator
+            io.openshift.build.commit.id: 0ab7429f9e91f50b5388268bf957f506118cbbd6
+            io.openshift.build.commit.url: https://github.com/openshift/sriov-network-operator/commit/0ab7429f9e91f50b5388268bf957f506118cbbd6
+            io.openshift.build.source-location: https://github.com/openshift/sriov-network-operator
+            io.openshift.maintainer.component: Networking
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.maintainer.subcomponent: SR-IOV
+            io.openshift.tags: openshift,networking,sr-iov
+            maintainer: Multus team <multus-dev@redhat.com>
+            name: openshift/ose-sriov-network-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-sriov-network-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 62f4332490eef03d61c2710baa3e17faae7aaa92
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:1bf775f662528cbbbab881b78eabbff551c27f5c678429ec87feff3cc84bd87d
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-network-operator-metadata:rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-network-operator-metadata@sha256:1bf775f662528cbbbab881b78eabbff551c27f5c678429ec87feff3cc84bd87d
+      tags:
+      - rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
     image:
       arch: x86_64
   filename: docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
@@ -23,6 +99,44 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: s390x
+            build-date: '2020-07-07T07:32:48.805411'
+            com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+            com.redhat.component: sriov-network-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is the component that manange and config sriov component
+              in Openshift cluster
+            distribution-scope: public
+            io.k8s.description: This is the component that manange and config sriov
+              component in Openshift cluster
+            io.k8s.display-name: OpenShift sriov-network-operator
+            io.openshift.build.commit.id: 0ab7429f9e91f50b5388268bf957f506118cbbd6
+            io.openshift.build.commit.url: https://github.com/openshift/sriov-network-operator/commit/0ab7429f9e91f50b5388268bf957f506118cbbd6
+            io.openshift.build.source-location: https://github.com/openshift/sriov-network-operator
+            io.openshift.maintainer.component: Networking
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.maintainer.subcomponent: SR-IOV
+            io.openshift.tags: openshift,networking,sr-iov
+            maintainer: Multus team <multus-dev@redhat.com>
+            name: openshift/ose-sriov-network-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-sriov-network-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 62f4332490eef03d61c2710baa3e17faae7aaa92
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:b114fc0ff28650327a061d944ccc0ed4c20d16f32a826d8748b32439807e714f
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-network-operator-metadata:rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-network-operator-metadata@sha256:b114fc0ff28650327a061d944ccc0ed4c20d16f32a826d8748b32439807e714f
+      tags:
+      - rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
     image:
       arch: s390x
   filename: docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
@@ -30,6 +144,44 @@ archives:
   type_name: tar
 - btype: image
   extra:
+    docker:
+      config:
+        config:
+          Labels:
+            architecture: ppc64le
+            build-date: '2020-07-07T07:32:50.285197'
+            com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
+            com.redhat.component: sriov-network-operator-metadata-container
+            com.redhat.delivery.appregistry: 'true'
+            com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+            description: This is the component that manange and config sriov component
+              in Openshift cluster
+            distribution-scope: public
+            io.k8s.description: This is the component that manange and config sriov
+              component in Openshift cluster
+            io.k8s.display-name: OpenShift sriov-network-operator
+            io.openshift.build.commit.id: 0ab7429f9e91f50b5388268bf957f506118cbbd6
+            io.openshift.build.commit.url: https://github.com/openshift/sriov-network-operator/commit/0ab7429f9e91f50b5388268bf957f506118cbbd6
+            io.openshift.build.source-location: https://github.com/openshift/sriov-network-operator
+            io.openshift.maintainer.component: Networking
+            io.openshift.maintainer.product: OpenShift Container Platform
+            io.openshift.maintainer.subcomponent: SR-IOV
+            io.openshift.tags: openshift,networking,sr-iov
+            maintainer: Multus team <multus-dev@redhat.com>
+            name: openshift/ose-sriov-network-operator-metadata
+            release: '1'
+            url: https://access.redhat.com/containers/#/registry.access.redhat.com/openshift/ose-sriov-network-operator-metadata/images/v4.3.28.202006290519.p0.prod-1
+            vcs-ref: 62f4332490eef03d61c2710baa3e17faae7aaa92
+            vcs-type: git
+            vendor: Red Hat, Inc.
+            version: v4.3.28.202006290519.p0.prod
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:00a74f6340dc8defd262b67e02c596e6ec7ad40238943fd5cc2bb911caf1a0de
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-network-operator-metadata:rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
+      - registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-sriov-network-operator-metadata@sha256:00a74f6340dc8defd262b67e02c596e6ec7ad40238943fd5cc2bb911caf1a0de
+      tags:
+      - rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
     image:
       arch: ppc64le
   filename: docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz

--- a/tests/koji/data/dump
+++ b/tests/koji/data/dump
@@ -7,7 +7,12 @@
 #
 #   tests/koji/data/dump https://koji.example.com/hub/ my-build-nvr
 #
+# Or, to redump *all* builds (useful if format changes):
+#
+#   tests/koji/data/dump https://koji.example.com/hub/ all
+#
 import os
+import glob
 import koji
 import sys
 import yaml
@@ -42,13 +47,19 @@ def sanitized_build(build):
 def sanitized_archive_extra(extra):
     out = {}
 
-    if not extra.get("docker"):
-        return out
-
     if "image" in extra:
         out["image"] = extra["image"]
 
-    # Will likely need 'docker' here soon
+    if "docker" in extra:
+        out["docker"] = {}
+        out["docker"]["repositories"] = extra["docker"]["repositories"]
+        out["docker"]["tags"] = extra["docker"]["tags"]
+        out["docker"]["digests"] = extra["docker"]["digests"]
+        out["docker"]["config"] = {}
+        out["docker"]["config"]["config"] = {}
+        out["docker"]["config"]["config"]["Labels"] = extra["docker"]["config"][
+            "config"
+        ]["Labels"]
 
     return out
 
@@ -72,17 +83,16 @@ def sanitized_archives(archives):
     return out
 
 
-def run(server_url, nvr):
-    server = koji.ClientSession(server_url)
+def dump_build(session, nvr):
 
-    build = server.getBuild(nvr)
+    build = session.getBuild(nvr)
 
     # In case user passed an ID
     nvr = build["nvr"]
 
     build = sanitized_build(build)
 
-    archives = server.listArchives(build["id"])
+    archives = session.listArchives(build["id"])
     archives = sanitized_archives(archives)
     build["archives"] = archives
 
@@ -93,6 +103,27 @@ def run(server_url, nvr):
         fh.write("#\n")
         yaml.dump(build, fh)
     print("Wrote to", data_file)
+
+
+def get_all_nvrs():
+    out = []
+    for build_file in glob.glob(BUILDS_DIR + "/*.yaml"):
+        with open(build_file, "rt") as f:
+            data = yaml.load(f, Loader=yaml.SafeLoader)
+            out.append(data["nvr"])
+    return out
+
+
+def run(server_url, nvr):
+    server = koji.ClientSession(server_url)
+
+    if nvr == "all":
+        nvrs = get_all_nvrs()
+    else:
+        nvrs = [nvr]
+
+    for nvr in nvrs:
+        dump_build(server, nvr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Having progressed with support for container images, I've learned
exactly which fields are needed on koji builds. Update the dump
utility to support them all.

Also make it support an 'all' NVR which redumps all existing builds,
so when the format changes like this it's possible to regenerate
them all easily.