### PR TITLE
Introduce SourceContainerImagePushItem

### DIFF
--- a/src/pushsource/__init__.py
+++ b/src/pushsource/__init__.py
@@ -9,6 +9,7 @@ from pushsource._impl.model import (
     ProductIdPushItem,
     RpmPushItem,
     ContainerImagePushItem,
+    SourceContainerImagePushItem,
     OperatorManifestPushItem,
     AmiPushItem,
     AmiRelease,

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -19,6 +19,7 @@ from ..model import (
     ModuleMdSourcePushItem,
     OperatorManifestPushItem,
     ContainerImagePushItem,
+    SourceContainerImagePushItem,
 )
 from ..helpers import list_argument, try_int
 from .modulemd import Module
@@ -409,8 +410,13 @@ class KojiSource(Source):
             path = self._pathinfo.typedir(meta, archive["btype"])
             item_src = os.path.join(path, archive["filename"])
 
+            klass = ContainerImagePushItem
+            if image.get("sources_for_nvr"):
+                # This is a source image.
+                klass = SourceContainerImagePushItem
+
             out.append(
-                ContainerImagePushItem(
+                klass(
                     # TODO: name might be changed once we start parsing
                     # the metadata from atomic-reactor.
                     name=archive["filename"],

--- a/src/pushsource/_impl/model/__init__.py
+++ b/src/pushsource/_impl/model/__init__.py
@@ -8,7 +8,11 @@ from .erratum import (
 )
 from .rpm import RpmPushItem
 from .file import FilePushItem
-from .container import ContainerImagePushItem, OperatorManifestPushItem
+from .container import (
+    ContainerImagePushItem,
+    SourceContainerImagePushItem,
+    OperatorManifestPushItem,
+)
 from .modulemd import ModuleMdPushItem, ModuleMdSourcePushItem
 from .comps import CompsXmlPushItem
 from .productid import ProductIdPushItem

--- a/src/pushsource/_impl/model/container.py
+++ b/src/pushsource/_impl/model/container.py
@@ -32,6 +32,18 @@ class ContainerImagePushItem(PushItem):
 
 
 @attr.s()
+class SourceContainerImagePushItem(ContainerImagePushItem):
+    """A :class:`~pushsource.PushItem` representing a source container image.
+
+    Source container images are a special type of image which are not runnable
+    but instead contain the packaged source code of a related binary image.
+
+    See `this article <https://access.redhat.com/articles/3410171>`_ for more
+    information on source container images.
+    """
+
+
+@attr.s()
 class OperatorManifestPushItem(PushItem):
     """A :class:`~pushsource.PushItem` representing an operator manifests archive
     (typically named ``operator_manifests.zip``).

--- a/tests/baseline/cases/koji-source-container.yml
+++ b/tests/baseline/cases/koji-source-container.yml
@@ -1,0 +1,25 @@
+# A pushsource library testcase.
+#
+# This file was generated from a template.
+# To regenerate, run test_baseline.py with PUSHSOURCE_UPDATE_BASELINE=1.
+
+# URL of Source to test.
+url: "kojitest:container_build=openstack-swift-container-container-source-16.1.6-6.1"
+
+# Push items generated from above.
+items:
+- SourceContainerImagePushItem:
+    build: openstack-swift-container-container-source-16.1.6-6.1
+    build_info:
+      name: openstack-swift-container-container-source
+      release: '6.1'
+      version: 16.1.6
+    dest: []
+    dest_signing_key: null
+    md5sum: null
+    name: docker-image-sha256:bfe520f7c81aeb3eaeb732ab93dd76b279b6a01a16a27f1ec34d5b2fcefbb363.x86_64.tar.gz
+    origin: null
+    sha256sum: null
+    signing_key: null
+    src: {{ koji_dir }}/packages/openstack-swift-container-container-source/16.1.6/6.1/images/docker-image-sha256:bfe520f7c81aeb3eaeb732ab93dd76b279b6a01a16a27f1ec34d5b2fcefbb363.x86_64.tar.gz
+    state: PENDING

--- a/tests/koji/data/builds/openstack-swift-container-container-source-16.1.6-6.1.yaml
+++ b/tests/koji/data/builds/openstack-swift-container-container-source-16.1.6-6.1.yaml
@@ -1,0 +1,38 @@
+############### GENERATED TEST DATA ########################
+# This file was created by tests/koji/data/dump script.
+#
+archives:
+- btype: image
+  extra:
+    docker:
+      config:
+        config: {}
+      digests:
+        application/vnd.docker.distribution.manifest.v2+json: sha256:9ab2d821d9cd40e2483582d418191d2548e2b839ac26c4bfd1a9996dca773f0f
+      repositories:
+      - registry-proxy.engineering.redhat.com/rh-osbs/rhosp16-openstack-swift-container:rhos-16.1-rhel-8-containers-candidate-83243-20210621202300-x86_64
+      - registry-proxy.engineering.redhat.com/rh-osbs/rhosp16-openstack-swift-container@sha256:9ab2d821d9cd40e2483582d418191d2548e2b839ac26c4bfd1a9996dca773f0f
+      tags:
+      - rhos-16.1-rhel-8-containers-candidate-83243-20210621202300-x86_64
+    image:
+      arch: x86_64
+  filename: docker-image-sha256:bfe520f7c81aeb3eaeb732ab93dd76b279b6a01a16a27f1ec34d5b2fcefbb363.x86_64.tar.gz
+  id: 5126790
+  type_name: tar
+extra:
+  image:
+    media_types:
+    - application/vnd.docker.distribution.manifest.v2+json
+    sources_for_nvr: openstack-swift-container-container-16.1.6-6
+    sources_signing_intent: release
+  typeinfo:
+    image:
+      media_types:
+      - application/vnd.docker.distribution.manifest.v2+json
+      sources_for_nvr: openstack-swift-container-container-16.1.6-6
+      sources_signing_intent: release
+id: 1640546
+name: openstack-swift-container-container-source
+nvr: openstack-swift-container-container-source-16.1.6-6.1
+release: '6.1'
+version: 16.1.6

--- a/tests/koji/data/dump
+++ b/tests/koji/data/dump
@@ -57,9 +57,14 @@ def sanitized_archive_extra(extra):
         out["docker"]["digests"] = extra["docker"]["digests"]
         out["docker"]["config"] = {}
         out["docker"]["config"]["config"] = {}
-        out["docker"]["config"]["config"]["Labels"] = extra["docker"]["config"][
-            "config"
-        ]["Labels"]
+
+        try:
+            out["docker"]["config"]["config"]["Labels"] = extra["docker"]["config"][
+                "config"
+            ]["Labels"]
+        except KeyError:
+            # Not always available
+            pass
 
     return out
 


### PR DESCRIPTION
Source container images are significantly different in nature from a
regular container image and they don't get pushed in the same way.
Introduce a subtype for them.