### PR TITLE
Add miscellaneous container image fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ koji>=1.18
 six
 pushcollector
 PyYAML
+frozendict; python_version >= '3.6'
 frozenlist2
 python-dateutil
 kobo

--- a/src/pushsource/_impl/backend/koji_containers.py
+++ b/src/pushsource/_impl/backend/koji_containers.py
@@ -1,0 +1,65 @@
+# Helpers for dealing with container metadata from koji.
+
+
+class ContainerArchiveHelper(object):
+    def __init__(self, archive):
+        self._archive = archive
+
+    @property
+    def archive_extra(self):
+        return self._archive.get("extra") or {}
+
+    @property
+    def archive_docker(self):
+        return self.archive_extra.get("docker") or {}
+
+    @property
+    def source_tags(self):
+        return self.archive_docker.get("tags") or []
+
+    @property
+    def arch(self):
+        config = self.archive_docker.get("config") or {}
+        image = self.archive_extra.get("image") or {}
+
+        out = config.get("architecture")
+
+        if not out:
+            # Ideally we got the arch from 'config' which will use the
+            # docker-native arch strings. For ancient/weird builds we may
+            # have had to fall back to 'image'.
+            out = image.get("arch")
+
+            # In this case, we get koji's native arch strings instead
+            # which can be different. Convert them to the terms used in
+            # the container world so we get consistent output.
+            archmap = {"x86_64": "amd64", "aarch64": "arm64"}
+            out = archmap.get(out, out)
+
+        return out
+
+    @property
+    def labels(self):
+        out = {}
+
+        config = self.archive_docker.get("config") or {}
+        # yes, config.config is the expected structure
+        config = config.get("config") or {}
+        raw_labels = config.get("Labels") or {}
+
+        # We are going to be a bit selective with the labels we return.
+        # The reason for this is just to keep a higher level of control
+        # over the data we produce. Labels include all sorts of random
+        # stuff and it'd be best not to use them in some cases and instead
+        # require proper fields to be added onto our models.
+        #
+        # "com.redhat." is permitted because fields in that namespace are
+        # known to be required for some operator images, e.g.
+        # com.redhat.openshift.versions documented at
+        # https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory
+        # which has its own non-trivial syntax we don't want to get into parsing.
+        for (key, value) in raw_labels.items():
+            if key.startswith("com.redhat."):
+                out[key] = value
+
+        return out

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -23,6 +23,7 @@ from ..model import (
 )
 from ..helpers import list_argument, try_int
 from .modulemd import Module
+from .koji_containers import ContainerArchiveHelper
 
 LOG = logging.getLogger("pushsource")
 CACHE_LOCK = threading.RLock()
@@ -410,6 +411,8 @@ class KojiSource(Source):
             path = self._pathinfo.typedir(meta, archive["btype"])
             item_src = os.path.join(path, archive["filename"])
 
+            helper = ContainerArchiveHelper(archive)
+
             klass = ContainerImagePushItem
             if image.get("sources_for_nvr"):
                 # This is a source image.
@@ -433,6 +436,9 @@ class KojiSource(Source):
                         version=meta["version"],
                         release=meta["release"],
                     ),
+                    source_tags=helper.source_tags,
+                    labels=helper.labels,
+                    arch=helper.arch,
                 )
             )
 

--- a/src/pushsource/_impl/compat.py
+++ b/src/pushsource/_impl/compat.py
@@ -1,9 +1,19 @@
 # Helpers for py2 vs py3 compatibility issues.
 
+import sys
+
 try:
     from os import scandir
 except ImportError:  # pragma: no cover
     # expected path for python <3.5
     from scandir import scandir
 
-__all__ = ["scandir"]
+if sys.version_info >= (3, 0):
+    # It is preferred to use immutable dicts when possible
+    from frozendict import frozendict
+else:  # pragma: no cover
+    # But it's not available on py2, fall back to plain old dicts there
+    frozendict = dict
+
+
+__all__ = ["scandir", "frozendict"]

--- a/src/pushsource/_impl/model/container.py
+++ b/src/pushsource/_impl/model/container.py
@@ -1,5 +1,8 @@
+from frozenlist2 import frozenlist
+
 from .base import PushItem
 from .. import compat_attr as attr
+from ..compat import frozendict
 
 
 @attr.s()
@@ -28,6 +31,29 @@ class ContainerImagePushItem(PushItem):
     See `container-signature`_ docs for information on signatures.
 
     .. _container-signature: https://github.com/containers/image/blob/33bcba75bb181318608f989e18e086f0d83d254c/docs/containers-signature.5.md
+    """
+
+    source_tags = attr.ib(
+        type=list, default=attr.Factory(frozenlist), converter=frozenlist
+    )
+    """Tags placed onto this image when it was built, if known.
+
+    :type: List[str]
+    """
+
+    labels = attr.ib(type=dict, default=attr.Factory(frozendict), converter=frozendict)
+    """Labels of this image, if known.
+
+    This field is not guaranteed to include all labels associated with the image.
+
+    :type: Dict[str, str]
+    """
+
+    arch = attr.ib(type=str, default=None)
+    """Architecture of this image, if known.
+
+    This field uses the conventional architecture strings used throughout the
+    container ecosystem, such as ``"amd64"``.
     """
 
 

--- a/tests/baseline/cases/errata-containers-legacy-repos.yml
+++ b/tests/baseline/cases/errata-containers-legacy-repos.yml
@@ -9,6 +9,7 @@ url: "erratatest:errata=RHBA-2020:2807&legacy_container_repos=yes"
 # Push items generated from above.
 items:
 - ContainerImagePushItem:
+    arch: s390x
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-logging-operator-metadata-container
@@ -19,14 +20,22 @@ items:
     - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
     src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-logging-operator-metadata-container
@@ -37,14 +46,22 @@ items:
     - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
     src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-logging-operator-metadata-container
@@ -55,14 +72,22 @@ items:
     - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
     src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-logging-operator-metadata-container
@@ -73,14 +98,22 @@ items:
     - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-06.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
     src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-nfd-operator-metadata-container
@@ -91,14 +124,22 @@ items:
     - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
     src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-nfd-operator-metadata-container
@@ -109,14 +150,22 @@ items:
     - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
     src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-nfd-operator-metadata-container
@@ -127,14 +176,22 @@ items:
     - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
     src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-nfd-operator-metadata-container
@@ -145,14 +202,22 @@ items:
     - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
     src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: elasticsearch-operator-metadata-container
@@ -163,14 +228,22 @@ items:
     - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-80524-20200707075228-ppc64le
     src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: elasticsearch-operator-metadata-container
@@ -181,14 +254,22 @@ items:
     - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50417-20200707075226-aarch64
     src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: elasticsearch-operator-metadata-container
@@ -199,14 +280,22 @@ items:
     - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-02.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
     src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: elasticsearch-operator-metadata-container
@@ -217,14 +306,22 @@ items:
     - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
     src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: local-storage-operator-metadata-container
@@ -235,14 +332,22 @@ items:
     - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
     src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: local-storage-operator-metadata-container
@@ -253,14 +358,22 @@ items:
     - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
     src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: local-storage-operator-metadata-container
@@ -271,14 +384,22 @@ items:
     - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c2-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
     src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: local-storage-operator-metadata-container
@@ -289,14 +410,22 @@ items:
     - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
     src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
@@ -308,14 +437,22 @@ items:
     - redhat-openshift4-ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-46533-20200707080442-aarch64
     src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
@@ -327,14 +464,22 @@ items:
     - redhat-openshift4-ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-02.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-13114-20200707080444-ppc64le
     src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
@@ -346,14 +491,22 @@ items:
     - redhat-openshift4-ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-12704-20200707080441-x86_64
     src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
@@ -365,14 +518,22 @@ items:
     - redhat-openshift4-ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-48676-20200707080442-s390x
     src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-template-service-broker-operator-metadata-container
@@ -383,14 +544,22 @@ items:
     - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
     src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-template-service-broker-operator-metadata-container
@@ -401,14 +570,22 @@ items:
     - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
     src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-template-service-broker-operator-metadata-container
@@ -419,14 +596,22 @@ items:
     - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-04.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
     src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-template-service-broker-operator-metadata-container
@@ -437,14 +622,22 @@ items:
     - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
     src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-metering-ansible-operator-metadata-container
@@ -455,14 +648,22 @@ items:
     - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
     src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-metering-ansible-operator-metadata-container
@@ -473,14 +674,22 @@ items:
     - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
     src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-metering-ansible-operator-metadata-container
@@ -491,14 +700,22 @@ items:
     - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
     src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-metering-ansible-operator-metadata-container
@@ -509,14 +726,22 @@ items:
     - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
     src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-ptp-operator-metadata-container
@@ -527,14 +752,22 @@ items:
     - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
     src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-ptp-operator-metadata-container
@@ -545,14 +778,22 @@ items:
     - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c2-vm-02.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
     src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-ptp-operator-metadata-container
@@ -563,14 +804,22 @@ items:
     - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1008.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
     src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-ptp-operator-metadata-container
@@ -581,14 +830,22 @@ items:
     - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-76837-20200707072220-aarch64
     src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: sriov-network-operator-metadata-container
@@ -599,14 +856,22 @@ items:
     - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
     src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: sriov-network-operator-metadata-container
@@ -617,14 +882,22 @@ items:
     - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
     src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: sriov-network-operator-metadata-container
@@ -635,14 +908,22 @@ items:
     - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
     src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: sriov-network-operator-metadata-container
@@ -653,11 +934,18 @@ items:
     - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
     src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
     state: PENDING
 - ErratumPushItem:

--- a/tests/baseline/cases/errata-containers.yml
+++ b/tests/baseline/cases/errata-containers.yml
@@ -9,6 +9,7 @@ url: "erratatest:errata=RHBA-2020:2807"
 # Push items generated from above.
 items:
 - ContainerImagePushItem:
+    arch: s390x
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-logging-operator-metadata-container
@@ -19,14 +20,22 @@ items:
     - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
     src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-logging-operator-metadata-container
@@ -37,14 +46,22 @@ items:
     - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
     src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-logging-operator-metadata-container
@@ -55,14 +72,22 @@ items:
     - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
     src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-logging-operator-metadata-container
@@ -73,14 +98,22 @@ items:
     - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-06.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
     src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-nfd-operator-metadata-container
@@ -91,14 +124,22 @@ items:
     - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
     src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-nfd-operator-metadata-container
@@ -109,14 +150,22 @@ items:
     - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
     src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-nfd-operator-metadata-container
@@ -127,14 +176,22 @@ items:
     - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
     src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: cluster-nfd-operator-metadata-container
@@ -145,14 +202,22 @@ items:
     - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
     src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: elasticsearch-operator-metadata-container
@@ -163,14 +228,22 @@ items:
     - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-80524-20200707075228-ppc64le
     src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: elasticsearch-operator-metadata-container
@@ -181,14 +254,22 @@ items:
     - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50417-20200707075226-aarch64
     src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: elasticsearch-operator-metadata-container
@@ -199,14 +280,22 @@ items:
     - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-02.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
     src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: elasticsearch-operator-metadata-container
@@ -217,14 +306,22 @@ items:
     - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
     src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: local-storage-operator-metadata-container
@@ -235,14 +332,22 @@ items:
     - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
     src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: local-storage-operator-metadata-container
@@ -253,14 +358,22 @@ items:
     - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
     src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: local-storage-operator-metadata-container
@@ -271,14 +384,22 @@ items:
     - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c2-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
     src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: local-storage-operator-metadata-container
@@ -289,14 +410,22 @@ items:
     - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
     src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
@@ -308,14 +437,22 @@ items:
     - openshift4/ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-46533-20200707080442-aarch64
     src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
@@ -327,14 +464,22 @@ items:
     - openshift4/ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-02.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-13114-20200707080444-ppc64le
     src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
@@ -346,14 +491,22 @@ items:
     - openshift4/ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-12704-20200707080441-x86_64
     src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
@@ -365,14 +518,22 @@ items:
     - openshift4/ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-ansible-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-ansible-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-48676-20200707080442-s390x
     src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-template-service-broker-operator-metadata-container
@@ -383,14 +544,22 @@ items:
     - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
     src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-template-service-broker-operator-metadata-container
@@ -401,14 +570,22 @@ items:
     - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
     src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-template-service-broker-operator-metadata-container
@@ -419,14 +596,22 @@ items:
     - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-04.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
     src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: openshift-enterprise-template-service-broker-operator-metadata-container
@@ -437,14 +622,22 @@ items:
     - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
     src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-metering-ansible-operator-metadata-container
@@ -455,14 +648,22 @@ items:
     - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
     src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-metering-ansible-operator-metadata-container
@@ -473,14 +674,22 @@ items:
     - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
     src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-metering-ansible-operator-metadata-container
@@ -491,14 +700,22 @@ items:
     - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
     src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-metering-ansible-operator-metadata-container
@@ -509,14 +726,22 @@ items:
     - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
     src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-ptp-operator-metadata-container
@@ -527,14 +752,22 @@ items:
     - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
     src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-ptp-operator-metadata-container
@@ -545,14 +778,22 @@ items:
     - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c2-vm-02.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
     src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-ptp-operator-metadata-container
@@ -563,14 +804,22 @@ items:
     - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1008.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
     src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: ose-ptp-operator-metadata-container
@@ -581,14 +830,22 @@ items:
     - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-76837-20200707072220-aarch64
     src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: amd64
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: sriov-network-operator-metadata-container
@@ -599,14 +856,22 @@ items:
     - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
     src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: ppc64le
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: sriov-network-operator-metadata-container
@@ -617,14 +882,22 @@ items:
     - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
     src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: s390x
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: sriov-network-operator-metadata-container
@@ -635,14 +908,22 @@ items:
     - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
     src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
     state: PENDING
 - ContainerImagePushItem:
+    arch: arm64
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
       name: sriov-network-operator-metadata-container
@@ -653,11 +934,18 @@ items:
     - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
     - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
     origin: RHBA-2020:2807
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
     src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
     state: PENDING
 - ErratumPushItem:

--- a/tests/baseline/cases/koji-source-container.yml
+++ b/tests/baseline/cases/koji-source-container.yml
@@ -9,6 +9,7 @@ url: "kojitest:container_build=openstack-swift-container-container-source-16.1.6
 # Push items generated from above.
 items:
 - SourceContainerImagePushItem:
+    arch: amd64
     build: openstack-swift-container-container-source-16.1.6-6.1
     build_info:
       name: openstack-swift-container-container-source
@@ -16,10 +17,13 @@ items:
       version: 16.1.6
     dest: []
     dest_signing_key: null
+    labels: {}
     md5sum: null
     name: docker-image-sha256:bfe520f7c81aeb3eaeb732ab93dd76b279b6a01a16a27f1ec34d5b2fcefbb363.x86_64.tar.gz
     origin: null
     sha256sum: null
     signing_key: null
+    source_tags:
+    - rhos-16.1-rhel-8-containers-candidate-83243-20210621202300-x86_64
     src: {{ koji_dir }}/packages/openstack-swift-container-container-source/16.1.6/6.1/images/docker-image-sha256:bfe520f7c81aeb3eaeb732ab93dd76b279b6a01a16a27f1ec34d5b2fcefbb363.x86_64.tar.gz
     state: PENDING


### PR DESCRIPTION
Adds a few fields known to be used by consumers:

- architecture of image

- source_tags (tags used by build system). Sometimes used to set
  default tags during push.

- labels, at least com.redhat.*, used for determining whether an
  image includes operator metadata.