### PR TITLE
koji: tolerate container builds with empty 'image'

### DIFF
--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -374,7 +374,7 @@ class KojiSource(Source):
         # Per above doc, it is preferred to use the metadata under 'typeinfo' if present
         image = typeinfo.get("image") or extra.get("image")
 
-        if not image:
+        if image is None:
             message = "Build %s not recognized as a container image build" % nvr
             LOG.error(message)
             raise ValueError(message)


### PR DESCRIPTION
A minor tweak to tolerate cases of a container build which has an
'image' field present but an empty dict. Rather than refusing to
handle it, let's continue and generate near-empty push items.

This is probably irrelevant to any real builds produced in recent
years. The motivation is improved compatibility with Pub, which
does accept builds like this and has some tests based on it
(though it's unclear if any such builds actually exist beyond
Pub's testdata)