### PR TITLE
docs: update for completion of errata source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by architecture.
 - Added `ModuleMdSourcePushItem` class. Source modulemd documents are now represented
   by this class rather than `ModuleMdPushItem`.
-- Added minimal `ContainerImagePushItem` and `OperatorManifestPushItem` classes for
-  container images. These classes currently are of limited use as they do not yet
-  carry relevant metadata.
+- Added many classes for container-related content, supported by `koji` and `errata`
+  sources.
 
 ### Changed
 
 - `errata` source now produces `ModuleMdSourcePushItem` where applicable, and respects
   FTP paths from Errata Tool for these items.
+- `errata` source is now available for general use and is no longer marked as
+  a technical preview.
 
 ## [2.7.0] - 2021-06-10
 

--- a/docs/sources/errata.rst
+++ b/docs/sources/errata.rst
@@ -4,19 +4,10 @@ Source: errata
 The ``errata`` push source allows the loading of content from an instance of
 Errata Tool (or "ET").
 
-.. warning::
-
-  This push source is currently provided as a technical preview only and is
-  not recommended for production use!
-
-  - Lacks support for container images
-  - Lacks support for Errata Tool targets other than ``cdn``
-  - There is moderate risk of backwards-incompatible API changes in future releases
-    of the pushsource library
-
 Supported content types:
 
 * RPMs
+* Container images
 * Advisories
 
 

--- a/docs/sources/koji.rst
+++ b/docs/sources/koji.rst
@@ -9,6 +9,7 @@ The ``koji`` push source allows the loading of content from an instance of
 Supported content types:
 
 * RPMs
+* container images (with operator manifests if applicable)
 * modulemd YAML streams (yum repo metadata)
 
 Note that many features of the koji source requires having koji's volume(s) mounted
@@ -60,6 +61,21 @@ the desired modulemd files, as in example:
 
 ``koji:https://koji.fedoraproject.org/kojihub?module_build=flatpak-common-f32-3220200518173809.caf21102&module_filter_filename=modulemd.x86_64.txt,modulemd.s390x.txt``
 
+Accessing container images
+..........................
+
+Use the ``container_build`` parameter to request container images from one or
+more builds. Builds can be specified by NVR. Builds should be produced by
+`OSBS`_ or should use compatible metadata.
+
+``koji:https://koji.fedoraproject.org/kojihub?container_build=grafana-7-1``
+
+Push items produced in this case may include:
+
+- :class:`~pushsource.ContainerImagePushItem` - one for each available image
+- :class:`~pushsource.SourceContainerImagePushItem` - for source container images
+- :class:`~pushsource.OperatorManifestPushItem` - if images have attached operator
+  manifest archives
 
 Setting the destination for push items
 ......................................
@@ -91,3 +107,6 @@ Python API reference
 .. autoclass:: pushsource.KojiSource
    :members:
    :special-members: __init__
+
+
+.. _OSBS: https://osbs.readthedocs.io/

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -79,12 +79,14 @@ For detailed information, see the API reference of the associated class.
 +--------+-----------------------------------------------------------------------------+-----------------------------------+----------------------------------------------------+
 | Name   | Examples                                                                    | Class                             | Description                                        |
 +========+=============================================================================+===================================+====================================================+
-| koji   | ``koji:https://koji.fedoraproject.org?rpm=python3-3.7.5-2.fc31.x86_64.rpm`` | :class:`~pushsource.KojiSource`   | Obtain RPMs from a koji server                     |
+| koji   | ``koji:https://koji.fedoraproject.org?rpm=python3-3.7.5-2.fc31.x86_64.rpm`` | :class:`~pushsource.KojiSource`   | Obtain RPMs, container images and other content    |
+|        |                                                                             |                                   | from a koji server                                 |
 +--------+-----------------------------------------------------------------------------+-----------------------------------+----------------------------------------------------+
 | staged | ``staged:/mnt/vol/my/staged/content``                                       | :class:`~pushsource.StagedSource` | Obtain RPMs, files, AMIs and other content from    |
 |        |                                                                             |                                   | locally mounted filesystem                         |
 +--------+-----------------------------------------------------------------------------+-----------------------------------+----------------------------------------------------+
-| errata | ``errata:https://errata.example.com?errata=RHBA-2020:1234``                 | :class:`~pushsource.ErrataSource` | Obtain RPMs and advisory metadata from Errata Tool |
+| errata | ``errata:https://errata.example.com?errata=RHBA-2020:1234``                 | :class:`~pushsource.ErrataSource` | Obtain RPMs, container images and advisory         |
+|        |                                                                             |                                   | metadata from Errata Tool                          |
 +--------+-----------------------------------------------------------------------------+-----------------------------------+----------------------------------------------------+
 
 

--- a/src/pushsource/_impl/model/base.py
+++ b/src/pushsource/_impl/model/base.py
@@ -74,8 +74,6 @@ class PushItem(object):
     In the common case of a regular file, a push item name will simply be a filename,
     optionally including leading path components.
 
-    Container image manifests may provide their digest as the name.
-
     In all cases, a non-empty name must be provided.
     """
 


### PR DESCRIPTION
Errata source and all the new container-related push items are ready to
be taken into general use and have been tested with Pub already. Do a
pass over the docs to reflect this:

- update errata and koji source docs to mention container image support
- remove the note presenting errata source as a 'tech preview' since
  it's about to be put into production
- fix one inaccurate note about PushItem.name for container images