### PR TITLE
koji: avoid some duplicate logs

### DIFF
--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -332,7 +332,7 @@ class KojiSource(Source):
 
         if not meta:
             message = "Module build not found in koji: %s" % nvr
-            LOG.error(message)
+            LOG.debug(message)
             raise ValueError(message)
 
         build_id = meta["id"]
@@ -364,7 +364,7 @@ class KojiSource(Source):
 
         if not meta:
             message = "Container image build not found in koji: %s" % nvr
-            LOG.error(message)
+            LOG.debug(message)
             raise ValueError(message)
 
         # The metadata we are interested in is documented here:
@@ -376,7 +376,7 @@ class KojiSource(Source):
 
         if image is None:
             message = "Build %s not recognized as a container image build" % nvr
-            LOG.error(message)
+            LOG.debug(message)
             raise ValueError(message)
 
         build_id = meta["id"]
@@ -400,7 +400,7 @@ class KojiSource(Source):
                 "Could not find (exactly) one container image archive on koji build %s"
                 % nvr
             )
-            LOG.error(message)
+            LOG.debug(message)
             raise ValueError(message)
 
         out = []


### PR DESCRIPTION
In some error cases, a pattern was being used here like this:

- make an error message
- log the message as an ERROR
- raise exception with same message

The idea behind it is that, when raising the exception, we don't know
if anyone's going to catch it and log appropriately. If they don't,
then we may have created a situation we can't debug, and we'll surely
wish we had added that log message.

However, if the exception *is* caught and logged then this ends up with
duplicate messages.

Based on testing with Pub, the "duplicate message" case is more common,
so let's stop doing that and just raise the exception without logging an
error. We can still log as DEBUG, which will not show the message by
default but still gives us a way to enable the messages if needed.