### PR TITLE
examples: add better formatting to list-push-items

### DIFF
--- a/examples/list-push-items
+++ b/examples/list-push-items
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
-import os
 import logging
-import shutil
+import attr
 from argparse import ArgumentParser
+import subprocess
+
+import yaml
 
 from pushsource import Source
 
@@ -27,26 +29,41 @@ Source.register_backend(
 )
 
 
+def format_python(item):
+    return repr(item) + ","
+
+
+def format_python_black(item):
+    code = format_python(item)
+    return subprocess.check_output(["black", "-c", code], text=True).strip()
+
+
+def format_yaml(item):
+    data = {type(item).__name__: attr.asdict(item, recurse=True)}
+    return yaml.dump([data], Dumper=yaml.SafeDumper)
+
+
+FORMATTERS = {
+    "python": format_python,
+    "python-black": format_python_black,
+    "yaml": format_yaml,
+}
+
+
 def run(args):
     source = Source.get(args.src_url)
-    log.info("Loaded source %s", args.src_url)
+    log.info("# Loaded source %s", args.src_url)
+
+    formatter = FORMATTERS.get(args.format)
+
     itemcount = 0
 
-    by_dest = {}
     for pushitem in source:
-        for dest in pushitem.dest:
-            by_dest.setdefault(dest, []).append(pushitem)
+        out = formatter(pushitem)
+        log.info("%s", out)
         itemcount += 1
 
-    for dest in by_dest:
-        log.info("\n === %s ========================", dest)
-        for item in by_dest[dest]:
-            if item.src:
-                log.info("  %s %s", type(item).__name__, item.src)
-            else:
-                log.info("  %s", item)
-
-    log.info("%s item(s) found in source", itemcount)
+    log.info("# %s item(s) found in source", itemcount)
 
 
 def main():
@@ -54,6 +71,12 @@ def main():
 
     parser = ArgumentParser(
         description="Report on all push items(s) available from a given source"
+    )
+    parser.add_argument(
+        "--format",
+        default="python-black",
+        choices=["python", "python-black", "yaml"],
+        help="Output format",
     )
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("src_url", help="Push source URL")


### PR DESCRIPTION
list-push-items can be used to dump whatever push items are available
in a given source.

Previously, the output format was something ad-hoc put together.
Let's adjust the format and add some more useful options:

-  python: repr() of items (can be pasted straight back into python code and it'll work to create the items)

- python-black: like python but also formatted nicely

- yaml: dump all items as a YAML list

With these new formats you can copy-paste the output of this
script into some docs or a test and have it make sense.