### PR TITLE
Add enter/exit support to fix lifecycle/resource leak issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- `Source` instances now support `with` statements to ensure that resources are freed
+  when no longer required.
 
 ## [2.8.0] - 2021-06-25
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,9 @@ from pushsource import Source
 # Get a source of content; sources and their parameters can be
 # specified by URL. This source will use a couple of RPMs from
 # Fedora koji as the content source.
-source = Source.get('koji:https://koji.fedoraproject.org/kojihub?rpm=python3-3.7.5-2.fc31.x86_64.rpm,python3-3.7.5-2.fc31.src.rpm')
-
-# Iterate over the content and do something with it:
-for push_item in source:
+with Source.get('koji:https://koji.fedoraproject.org/kojihub?rpm=python3-3.7.5-2.fc31.x86_64.rpm,python3-3.7.5-2.fc31.src.rpm') as source:
+  # Iterate over the content and do something with it:
+  for push_item in source:
     publish(push_item)
 ```
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,14 +42,13 @@ according to their type and attributes:
     from pushsource import Source, RpmPushItem
     import logging
 
-    source = Source.get('koji:https://koji.fedoraproject.org/kojihub?rpm=rpm1,rpm2,...')
-
-    for item in source:
-        if isinstance(item, RpmPushItem):
-            # do something with RPMs
-            publish_rpm(item)
-        else:
-            # don't know what to do
-            logging.getLogger().warning("Unexpected item: %s", item)
+    with Source.get('koji:https://koji.fedoraproject.org/kojihub?rpm=rpm1,rpm2,...') as source:
+        for item in source:
+            if isinstance(item, RpmPushItem):
+                # do something with RPMs
+                publish_rpm(item)
+            else:
+                # don't know what to do
+                logging.getLogger().warning("Unexpected item: %s", item)
 
 For more information, see the :ref:`userguide`.

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -113,17 +113,16 @@ Example:
 
 ::
 
-  source = Source.get(...)
-
-  for item in source:
-    if isinstance(item, RpmPushItem):
-      publish_rpm(item)
-    elif isinstance(item, ErratumPushItem):
-      publish_erratum(item)
-    elif isinstance(item, FilePushItem):
-      publish_file(item)
-    else:
-      LOG.warning("Unexpected push item type: %s", item)
+  with Source.get(...) as source:
+    for item in source:
+      if isinstance(item, RpmPushItem):
+        publish_rpm(item)
+      elif isinstance(item, ErratumPushItem):
+        publish_erratum(item)
+      elif isinstance(item, FilePushItem):
+        publish_file(item)
+      else:
+        LOG.warning("Unexpected push item type: %s", item)
 
 
 .. _implementing:
@@ -145,10 +144,11 @@ To implement a backend, follow these steps:
     * If your backend has a customizable timeout, use an argument named `timeout` accepting
       a number of seconds.
 * Implement the ``__iter__`` method, while following conventions:
-    * Your source might be iterated over more than once.
     * Lazy loading of data is recommended where practical; i.e. prefer to implement a generator
       which yields each piece of data as it is ready, rather than eagerly loading all data
       into a list.
+* If your class allocates any resources which should be cleaned up when no longer needed,
+  implement ``__enter__`` and ``__exit__`` methods to manage them.
 * Call the :class:`~pushsource.Source.register_backend` method providing your backend's name
   and class as arguments.
 

--- a/examples/dump-pub-staged
+++ b/examples/dump-pub-staged
@@ -42,12 +42,12 @@ def dump_task(task_info):
         return
 
     log.info("STAGED: %s", ", ".join(stagedirs))
-    source = Source.get("staged:", url=stagedirs)
-    count = 0
-    for pushitem in source:
-        log.info("  %s", pushitem)
-        count += 1
-    log.info("=========== %s item(s) ================================", count)
+    with Source.get("staged:", url=stagedirs) as source:
+        count = 0
+        for pushitem in source:
+            log.info("  %s", pushitem)
+            count += 1
+        log.info("=========== %s item(s) ================================", count)
 
 
 def main():

--- a/examples/list-push-items
+++ b/examples/list-push-items
@@ -51,19 +51,19 @@ FORMATTERS = {
 
 
 def run(args):
-    source = Source.get(args.src_url)
-    log.info("# Loaded source %s", args.src_url)
+    with Source.get(args.src_url) as source:
+        log.info("# Loaded source %s", args.src_url)
 
-    formatter = FORMATTERS.get(args.format)
+        formatter = FORMATTERS.get(args.format)
 
-    itemcount = 0
+        itemcount = 0
 
-    for pushitem in source:
-        out = formatter(pushitem)
-        log.info("%s", out)
-        itemcount += 1
+        for pushitem in source:
+            out = formatter(pushitem)
+            log.info("%s", out)
+            itemcount += 1
 
-    log.info("# %s item(s) found in source", itemcount)
+        log.info("# %s item(s) found in source", itemcount)
 
 
 def main():

--- a/src/pushsource/_impl/backend/errata_source/errata_client.py
+++ b/src/pushsource/_impl/backend/errata_source/errata_client.py
@@ -22,8 +22,10 @@ class ErrataRaw(object):
 
 class ErrataClient(object):
     def __init__(self, threads, url, **retry_args):
-        self._executor = Executors.thread_pool(max_workers=threads).with_retry(
-            **retry_args
+        self._executor = (
+            Executors.thread_pool(max_workers=threads)
+            .with_retry(**retry_args)
+            .with_cancel_on_shutdown()
         )
         self._url = url
         self._tls = threading.local()
@@ -38,6 +40,9 @@ class ErrataClient(object):
             self._call_et, "get_advisory_cdn_docker_file_list"
         )
         self._get_ftp_paths = partial(self._call_et, "get_ftp_paths")
+
+    def shutdown(self):
+        self._executor.shutdown(True)
 
     @property
     def _errata_service(self):

--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -75,9 +75,17 @@ class StagedSource(
 
         # Note: this executor does not have a retry.
         # NFS already does a lot of its own retries.
-        self._executor = Executors.thread_pool(max_workers=threads).with_timeout(
-            timeout
+        self._executor = (
+            Executors.thread_pool(max_workers=threads)
+            .with_timeout(timeout)
+            .with_cancel_on_shutdown()
         )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._executor.shutdown()
 
     def __iter__(self):
         # Possible improvement would be to handle the separate dirs concurrently.

--- a/tests/baseline/test_baseline.py
+++ b/tests/baseline/test_baseline.py
@@ -3,6 +3,7 @@ import glob
 import functools
 import logging
 import difflib
+import threading
 
 import yaml
 import attr
@@ -183,8 +184,14 @@ def test_source_against_baseline(casename, case_helper):
 
     url = case_data["url"]
 
-    source = Source.get(url)
-    all_items = list(source)
+    # Each tested source is checked for thread leaks to encourage
+    # that enter/exit are implemented correctly.
+    threads = threading.active_count()
+
+    with Source.get(url) as source:
+        all_items = list(source)
+
+    assert threading.active_count() == threads
 
     new_case_text = case_helper.serialize(url, all_items)
 

--- a/tests/errata/test_errata_metadata.py
+++ b/tests/errata/test_errata_metadata.py
@@ -163,7 +163,8 @@ def test_errata_url_with_path(fake_errata_tool):
     assert not fake_errata_tool.last_url
 
     # Load all items
-    items = list(source)
+    with source:
+        items = list(source)
 
     # It should have queried the expected XML-RPC endpoint, which was
     # appended to the URL retaining our path component.

--- a/tests/errata/test_errata_modules.py
+++ b/tests/errata/test_errata_modules.py
@@ -171,7 +171,8 @@ def test_errata_modules_via_koji(fake_errata_tool, fake_koji, koji_dir):
         build_nvr="postgresql-12-8010120191120141335.e4e244f9",
     )
 
-    items = list(source)
+    with source:
+        items = list(source)
 
     errata_items = [i for i in items if isinstance(i, ErratumPushItem)]
     rpm_items = [i for i in items if isinstance(i, RpmPushItem)]

--- a/tests/koji/test_koji.py
+++ b/tests/koji/test_koji.py
@@ -79,7 +79,8 @@ def test_koji_rpms(fake_koji, koji_dir):
     }
 
     # Eagerly fetch
-    items = list(source)
+    with source:
+        items = list(source)
 
     # It should have constructed a session for the given URL
     assert fake_koji.last_url == "https://koji.example.com/"

--- a/tests/source/test_source_context.py
+++ b/tests/source/test_source_context.py
@@ -1,0 +1,72 @@
+from pushsource import Source, PushItem
+
+# Just some basic push items for test
+
+ITEMS = [PushItem(name="item1"), PushItem(name="item2")]
+
+
+class BasicInheritedSource(Source):
+    # A source which simply yields some stuff and didn't implement enter/exit
+    def __init__(self):
+        pass
+
+    def __iter__(self):
+        for item in ITEMS:
+            yield item
+
+
+class CustomSource(Source):
+    # A more complex source for testing with get_partial and custom enter/exit
+    def __init__(self, a, b, c, spy):
+        self.a = a
+        self.b = b
+        self.c = c
+        self.spy = spy
+
+    def __enter__(self):
+        self.spy.append("enter %s" % ([self.a, self.b, self.c]))
+        return self
+
+    def __exit__(self, *_args):
+        self.spy.append("exit %s" % ([self.a, self.b, self.c]))
+
+    def __iter__(self):
+        for item in ITEMS:
+            yield item
+
+
+def test_basic_inherited_source():
+    """Basic inherited push source can be used via with statement."""
+    Source.register_backend("basic", BasicInheritedSource)
+
+    with Source.get("basic:") as source:
+        assert list(source) == ITEMS
+
+
+def test_basic_iterable_source():
+    """Basic push source returning non-class iterable can be used via with statement."""
+    Source.register_backend("iterable", lambda *_: ITEMS)
+
+    # Even though lists don't have enter/exit, it should be automatically wrapped here
+    # so that it works.
+    with Source.get("iterable:") as source:
+        assert list(source) == ITEMS
+
+
+def test_custom_source():
+    """A push source with args, custom enter/exit and used with get_partial works."""
+    Source.register_backend("custom-base", CustomSource)
+
+    spy = []
+    Source.register_backend("custom-spy", Source.get_partial("custom-base:", spy=spy))
+
+    Source.register_backend("custom1", Source.get_partial("custom-spy:", a=123))
+    Source.register_backend("custom2", Source.get_partial("custom1:", b=234))
+    Source.register_backend("custom3", Source.get_partial("custom2:", c=456))
+
+    # Now use the source while going through multiple layers.
+    with Source.get("custom3:") as source:
+        assert list(source) == ITEMS
+
+    # the enter/exit should propagate all the way through, just once.
+    assert spy == ["enter [123, 234, 456]", "exit [123, 234, 456]"]


### PR DESCRIPTION
Previously, sources were used like this:

    source = Source.get(...)
    for item in source:
        ...

Problem: a lot of the sources spawn additional threads internally and
there was no way to clean them up other than relying on GC (which
is problematic if there can be cycles between threads).

This was a bit of a design flub which was missed since the typical
use-case for a source is to only create one of them in the lifecycle
of your task/script/etc. However, it becomes relevant in cases such
as test suites, where hundreds of tests might each create Source
instances - leading to hundreds of threads spawned and never cleaned
up until all tests finish.

To fix this we now provide support for with-statements, which really
should have been there since the beginning. Now the recommended way
to use a source is:

    with Source.get(...) as source:
        for item in source:
            ...

It is not technically mandatory to use it this way, so only a subset of
tests were updated to use with statements. Most notably the baseline
test was updated to verify that there are no thread leaks when a with
statement has been used.

A related note in docs about being able to iterate over sources more
than once has been removed. In practice, none of the sources were
designed for it and none are being used in that way, and the addition
of with statements makes the situation even less clear / less likely
to work, so just drop that for now.