### PR TITLE
pylint: disable unused-private-member

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -93,6 +93,8 @@ disable=print-statement,
         fixme,
         # some classes have code accessing each other
         protected-access,
+        # false positives on 'staged' backend
+        unused-private-member,
         # we use black code style and don't need additional checks
         bad-continuation,
         line-too-long,


### PR DESCRIPTION
pylint 2.9.0 (2021-06-29) introduced unused-private-member checker,
but it wrongly flags some of our code as unused (code using
@handles_type decorator in staged backend).