### PR TITLE
chore: updates from repo-playbooks


### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -12,21 +12,19 @@ jobs:
      - name: Setup Python
        uses: actions/setup-python@v2
        with:
-         # TODO: multi-version support
-         python-version: 3.8
+         python-version: "3.9"
 
      - name: Install system dependencies
-       run: sudo apt-get install -y libkrb5-dev
+       run: sudo apt-get install -y tox libkrb5-dev
+
      - name: pip-compile
        uses: technote-space/create-pr-action@v2
        with:
-         EXECUTE_COMMANDS: |
-           pip install pip-tools
-           pip-compile -U --generate-hashes test-requirements.in
-           
+         EXECUTE_COMMANDS: tox -e pip-compile
          COMMIT_MESSAGE: 'chore: scheduled pip-compile'
          COMMIT_NAME: 'GitHub Actions'
          COMMIT_EMAIL: 'noreply@github.com'
+         GITHUB_TOKEN: ${{ secrets.PIP_COMPILE_TOKEN }}
          PR_BRANCH_PREFIX: deps/
          PR_BRANCH_NAME: 'pip-compile'
          PR_TITLE: 'chore: scheduled pip-compile'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release on PyPI
+
+on:
+  push:
+    tags:
+    - v*
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,22 @@
 repos:
+
 -   repo: https://github.com/ambv/black
-    rev: 026c81b83454f176a9f9253cbfb70be2c159d822
+    rev: 21.6b0
     hooks:
     - id: black
-      language_version: python3.6
 
+-   repo: https://github.com/pycqa/isort/
+    rev: 5.6.4
+    hooks:
+    - id: isort
+
+-   repo: https://github.com/frnmst/md-toc
+    rev: 8.0.0
+    hooks:
+    - id: md-toc
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+    - id: end-of-file-fixer
+    - id: trailing-whitespace

--- a/.pylintrc
+++ b/.pylintrc
@@ -215,7 +215,6 @@ enable=abstract-class-instantiated,
   subprocess-popen-preexec-fn,
   subprocess-run-check,
   super-init-not-called,
-  #super-with-arguments,  # enable when py2 dropped
   superfluous-parens,
   syntax-error,
   too-few-format-args,
@@ -270,4 +269,4 @@ enable=abstract-class-instantiated,
   wrong-spelling-in-comment,
   wrong-spelling-in-docstring,
   yield-inside-async-function,
-  yield-outside-function,
+  yield-outside-function

--- a/tox.ini
+++ b/tox.ini
@@ -48,3 +48,14 @@ commands=
 
 [pytest]
 testpaths = tests
+
+[testenv:pip-compile]
+# Recompile all requirements .txt files using pip-compile.
+# Don't edit me - I'm deployed from a template.
+deps = pip-tools
+basepython = python3.9
+skip_install = true
+skipsdist = true
+commands =
+    pip-compile -U --generate-hashes test-requirements.in -o test-requirements.txt
+# end pip-compile


### PR DESCRIPTION
## Automated update

This is an automated update generated by ansible playbooks.
See [the playbook repo](https://url.corp.redhat.com/300a997) for more information.

## Summary of updates
### update editorconfig

The [editorconfig](https://editorconfig.org/) file ensures consistent
handling of whitespace and other editor configuration.

#### Recent changes

- [a16f7ad](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/a16f7adcd1ae615e60a00fd560c1a8a77abf4561) `Introduce editorconfig role`


### update pip-compile workflow

This GitHub Actions workflow will regularly invoke pip-compile over
relevant files in this repo and submit pull requests when python dependencies need
updating.

#### Recent changes

- [0a10f85](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/0a10f857a4cc3209e9fcacef9ef32b4fac9b2928) `Fix python version issue for pip-compile`
- [3c68aac](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/3c68aac34e876d5d2737af0bdc47a73758e56c87) `repo_facts: add support for probing native deps`
- [33c0f02](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/33c0f026074aa1fa2fe08f8018656d9d338fafe2) `Refactor pip-compile to use tox`


### update tox config for pip-compile

Adds a tox environment for running pip-compile. This can be used either
locally or within CI to update all dependencies to the latest versions.

#### Recent changes

- [0a10f85](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/0a10f857a4cc3209e9fcacef9ef32b4fac9b2928) `Fix python version issue for pip-compile`
- [0c689de](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/0c689de772fb710d75c952ebcba9abe06d48b179) `pip-compile: drop unnecessary sdist/install steps`
- [668b7f3](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/668b7f342c3311fab46a690d2caf3c2d8d336b8f) `pip-compile: migrate to python3.9 as default`


### update pre-commit config

The pre-commit tool enforces consistency on all incoming changes.

#### Recent changes

- [2d0f586](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/2d0f58695872ba04d09aacb3a57f6b4aaf28f213) `Introduce md-toc to pre-commit`
- [47da301](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/47da3019fc34f35d4e17217f6efb72003bbb02b2) `pre-commit: enable some additional generic hooks`
- [686ea1b](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/686ea1ba38c6fb1ee57b7907a1a96243dc23c724) `Add a TODO list of other pre-commit hooks to investigate`


### update pylint config

Enables a stable and opinionated set of pylint checks which should
be appropriate for this project.

#### Recent changes

- [8503811](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/850381164be5a66ef48f54aed4d343aabb149a85) `Refactor repo_updates for improved messages`
- [7d2fa63](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/7d2fa6381f1b3504763a3a19ad13f580d6a9d63c) `pylint: sort checks`
- [97f778e](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/97f778eb5b756fb0d1764e98e14f0f02d6821bf6) `Add support for deployment of pylintrc`


### update pypi release workflow

This GitHub Actions workflow will release to PyPI whenever a "v{major.minor.patch}"
tag is created in the repository.

#### Recent changes

- [f031a91](https://gitlab.cee.redhat.com/rmcgover/repo-playbooks/-/commit/f031a91b9ffd08c23ee573b6c3946e53a662d30d) `Add role for pypi release action`

