### PR TITLE
refactor: give all executors a meaningful name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- Internally created executors are now named for improved metrics and debuggability.
 
 ## [2.9.0] - 2021-07-05
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs
-more-executors
+more-executors>=2.7.0
 koji>=1.18
 six
 pushcollector

--- a/src/pushsource/_impl/backend/errata_source/errata_client.py
+++ b/src/pushsource/_impl/backend/errata_source/errata_client.py
@@ -23,7 +23,7 @@ class ErrataRaw(object):
 class ErrataClient(object):
     def __init__(self, threads, url, **retry_args):
         self._executor = (
-            Executors.thread_pool(max_workers=threads)
+            Executors.thread_pool(name="pushsource-errata-client", max_workers=threads)
             .with_retry(**retry_args)
             .with_cancel_on_shutdown()
         )

--- a/src/pushsource/_impl/backend/errata_source/errata_source.py
+++ b/src/pushsource/_impl/backend/errata_source/errata_source.py
@@ -80,14 +80,14 @@ class ErrataSource(Source):
 
         # This executor doesn't use retry because koji & ET executors already do that.
         self._executor = Executors.thread_pool(
-            max_workers=threads
+            name="pushsource-errata", max_workers=threads
         ).with_cancel_on_shutdown()
 
         # We set aside a separate thread pool for koji so that there are separate
         # queues for ET and koji calls, yet we avoid creating a new thread pool for
         # each koji source.
         self._koji_executor = (
-            Executors.thread_pool(max_workers=threads)
+            Executors.thread_pool(name="pushsource-errata-koji", max_workers=threads)
             .with_retry()
             .with_cancel_on_shutdown()
         )

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -204,7 +204,7 @@ class KojiSource(Source):
         self._threads = threads
         self._executor = (
             executor
-            or Executors.thread_pool(max_workers=threads)
+            or Executors.thread_pool(name="pushsource-koji", max_workers=threads)
             .with_retry()
             .with_cancel_on_shutdown()
         )

--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -76,7 +76,7 @@ class StagedSource(
         # Note: this executor does not have a retry.
         # NFS already does a lot of its own retries.
         self._executor = (
-            Executors.thread_pool(max_workers=threads)
+            Executors.thread_pool(name="pushsource-staged", max_workers=threads)
             .with_timeout(timeout)
             .with_cancel_on_shutdown()
         )


### PR DESCRIPTION
Naming these is a good idea because:

- the name will be reused in any created threads, so we can
  figure out which code created which thread

- the name will appear in prometheus metrics