### PR TITLE
Fix koji version method

### DIFF
--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -255,7 +255,7 @@ class KojiSource(Source):
     def _koji_get_version(self):
         with CACHE_LOCK:
             if "koji_version" not in self._cache:
-                self._cache["koji_version"] = self._koji_session.getVersion()
+                self._cache["koji_version"] = self._koji_session.getKojiVersion()
             return self._cache["koji_version"]
 
     def _get_rpm(self, rpm):

--- a/tests/koji/fake_koji.py
+++ b/tests/koji/fake_koji.py
@@ -158,7 +158,7 @@ class FakeKojiSession(object):
             raise value
         return value
 
-    def getVersion(self):
+    def getKojiVersion(self):
         return "fake-version"
 
     def getRPM(self, rpm):


### PR DESCRIPTION
2.10.2 had a trivial but showstopping bug: the method we want to call
here is actually getKojiVersion, not getVersion. The latter doesn't
exist, which means the code immediately crashes when used against a real
koji server.