### PR TITLE
Use https for errata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea/

--- a/src/pushsource/_impl/helpers.py
+++ b/src/pushsource/_impl/helpers.py
@@ -1,6 +1,9 @@
 import six
 
 
+from six.moves.urllib.parse import urlparse, ParseResult
+
+
 def list_argument(value, retain_none=False):
     """Convert an argument into a list:
 
@@ -85,3 +88,22 @@ def try_bool(value):
     elif value in ["", "0", "false", "no"]:
         return False
     raise ValueError("Expected a boolean, got %s" % repr(value))
+
+
+def force_https(url):
+    """Force ``url`` to use https as its scheme.
+
+    Parameters:
+        url: str
+            A string representation of a URL.
+
+    Returns:
+        str
+            ``url`` with its scheme replaced with https.
+
+    Throws:
+        Any potential error thrown by the urlparse function during parsing.
+    """
+    parsed = urlparse(url)
+    with_https = ParseResult("https", *parsed[1:])
+    return with_https.geturl()

--- a/tests/errata/test_errata_metadata.py
+++ b/tests/errata/test_errata_metadata.py
@@ -17,9 +17,8 @@ def test_errata_typical_metadata(fake_errata_tool):
     items = list(source)
 
     # It should have queried the expected XML-RPC endpoint.
-    # Note that our https was replaced with http, this is expected!
     assert (
-        fake_errata_tool.last_url == "http://errata.example.com/errata/errata_service"
+        fake_errata_tool.last_url == "https://errata.example.com/errata/errata_service"
     )
 
     # It should have loaded that one advisory
@@ -168,10 +167,9 @@ def test_errata_url_with_path(fake_errata_tool):
 
     # It should have queried the expected XML-RPC endpoint, which was
     # appended to the URL retaining our path component.
-    # Note that our https was replaced with http, this is expected!
     assert (
         fake_errata_tool.last_url
-        == "http://errata.example.com/foo/bar/errata/errata_service"
+        == "https://errata.example.com/foo/bar/errata/errata_service"
     )
 
     # It should have got some data

--- a/tests/helpers/test_argument_helpers.py
+++ b/tests/helpers/test_argument_helpers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pushsource._impl.helpers import list_argument, try_bool
+from pushsource._impl.helpers import list_argument, try_bool, force_https
 
 
 def test_list_argument():
@@ -35,3 +35,29 @@ def test_try_bool(input, expected_output):
 def test_try_bool_invalid():
     with pytest.raises(ValueError):
         try_bool("this ain't no boolean")
+
+
+@pytest.mark.parametrize(
+    "input, expected_output",
+    [
+        ("http://errata.example.com/some/path", "https://errata.example.com/some/path"),
+        (
+            "https://errata.example.com/some/path",
+            "https://errata.example.com/some/path",
+        ),
+        (
+            "https://errata.example.com/some/path?param1=a",
+            "https://errata.example.com/some/path?param1=a",
+        ),
+        (
+            "https://errata.example.com/some/path#fragment",
+            "https://errata.example.com/some/path#fragment",
+        ),
+        (
+            "https://errata.example.com/some/path?param1=a#fragment",
+            "https://errata.example.com/some/path?param1=a#fragment",
+        ),
+    ],
+)
+def test_force_https(input, expected_output):
+    assert force_https(input) == expected_output


### PR DESCRIPTION
Update `ErrataSource` to use https rather than http for Errata Tool XML-RPC endpoint requests. 

Historically, the `ErrataSource` constructor allowed calling code to pass URLs with either http or https schemes, and would force http behind the scenes. For compatibility, the `ErrataSource` constructor still allows calling code to use http or https, but now forces https behind the scenes.