### PR TITLE
Mitigate spurious TimeoutError for slow caller [RHELDST-6064]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Changed
+
+- Mitigate spurious timeout error by using `as_completed_with_timeout_reset`
 
 ## [2.11.0] - 2021-09-15
 

--- a/src/pushsource/_impl/backend/errata_source/errata_source.py
+++ b/src/pushsource/_impl/backend/errata_source/errata_source.py
@@ -18,7 +18,12 @@ from ...model import (
     OperatorManifestPushItem,
     conv,
 )
-from ...helpers import list_argument, try_bool, force_https
+from ...helpers import (
+    list_argument,
+    try_bool,
+    force_https,
+    as_completed_with_timeout_reset,
+)
 
 LOG = logging.getLogger("pushsource")
 
@@ -480,7 +485,9 @@ class ErrataSource(Source):
                 self._executor.submit(self._push_items_from_raw, f.result())
             )
 
-        completed_fs = futures.as_completed(push_items_fs, timeout=self._timeout)
+        completed_fs = as_completed_with_timeout_reset(
+            push_items_fs, timeout=self._timeout
+        )
         for f in completed_fs:
             for pushitem in f.result():
                 yield pushitem

--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -4,8 +4,6 @@ import logging
 import itertools
 import functools
 
-from concurrent import futures
-
 import yaml
 import json
 
@@ -15,7 +13,7 @@ from pushcollector import Collector
 from more_executors import Executors
 
 from ...source import Source
-from ...helpers import list_argument
+from ...helpers import list_argument, as_completed_with_timeout_reset
 
 from .staged_utils import StagingMetadata, StagingLeafDir
 from .staged_ami import StagedAmiMixin
@@ -164,7 +162,9 @@ class StagedSource(
             self._executor.submit(process_dir, leafdir) for leafdir in all_leaf_dirs
         ]
 
-        completed_fs = futures.as_completed(pushitems_fs, timeout=self._timeout)
+        completed_fs = as_completed_with_timeout_reset(
+            pushitems_fs, timeout=self._timeout
+        )
         for f in completed_fs:
             for pushitem in f.result():
                 yield pushitem

--- a/src/pushsource/_impl/helpers.py
+++ b/src/pushsource/_impl/helpers.py
@@ -142,9 +142,6 @@ def as_completed_with_timeout_reset(futures, timeout):
         finished, pending = wait(pending, timeout=timeout, return_when=FIRST_COMPLETED)
         # no future finished in timeout given, raise TimeoutError
         if not finished:
-            # try to cancel futures, we can't cancel those already running or finished
-            for fs in pending:
-                fs.cancel()
             raise TimeoutError(
                 "%d (of %d) futures unfinished" % (len(pending), total_futures)
             )

--- a/tests/helpers/test_futures_timeout.py
+++ b/tests/helpers/test_futures_timeout.py
@@ -1,0 +1,53 @@
+import six
+
+# in py2 TimeoutError is not built-in exception
+if six.PY2:
+    from concurrent.futures import TimeoutError  # pylint: disable=redefined-builtin
+
+import pytest
+
+from pushsource._impl.helpers import as_completed_with_timeout_reset
+from more_executors.futures import f_return
+from more_executors import Executors
+from time import sleep
+
+
+def test_as_completed_with_timeout_reset():
+    # tests correctly yielded futures from as_completed_with_timeout_reset()
+    futures = [f_return(1), f_return(2)]
+    current = set()
+    for ft in as_completed_with_timeout_reset(futures, timeout=1):
+        value = ft.result()
+        current.add(value)
+
+    expected = set([1, 2])
+    assert current == expected
+
+
+def test_as_completed_with_timeout_reset_raises_timeout_error():
+    # tests raised TimeoutError when futures are slow
+    executor = Executors.thread_pool(1)
+    ft_1 = executor.submit(sleep, 1)
+    ft_2 = executor.submit(sleep, 0.5)
+
+    futures = [ft_1, ft_2]
+    with pytest.raises(TimeoutError) as exc:
+        for _ in as_completed_with_timeout_reset(futures, timeout=0.1):
+            pass
+
+    assert str(exc.value) == "2 (of 2) futures unfinished"
+
+
+def test_as_completed_with_timeout_reset_slow_caller():
+    # simulates slow caller, as_completed_with_timeout_reset() won't raise
+    # spurious TimeoutError
+    executor = Executors.thread_pool(1)
+    ft_1 = executor.submit(sleep, 0.2)
+    ft_2 = executor.submit(sleep, 0.3)
+
+    futures = [ft_1, ft_2]
+    for ft in as_completed_with_timeout_reset(futures, timeout=0.5):
+        ft.result()
+        # simulate slow caller
+        sleep(1.5)
+    # no exception raised


### PR DESCRIPTION
Mitigate spurious TimeoutError for slow caller [RHELDST-6064]

Previously iterating over any *Source object suffered from
spurious TimeoutError when caller was slow. The generator 'as_completed'
is unable to reset or stop timer for timeout, the timer for timeout
starts in original call to this generator.

Instead an alternative generator called 'as_completed_with_timeout_reset'
was implemented in helpers.py. It provides following functionality:
- yields finished futures as soon as any of them is finished
- after a finished future is yielded, there is no timeout check in
  place after yield
- timeout is only applied when next item from generator is requested

This approach allows caller to work as long as it needs, TimeoutError
is raised only in case when next requested item from pushsource
takes too long to yield to caller.

Fixed a couple of imports in order to pass pylint checks.
