### PR TITLE
docs: fix & tweak docs for new registry source

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ A library for accessing push items from various sources.
    sources/base
    sources/staged
    sources/koji
+   sources/registry
    sources/errata
    model/base
    model/files

--- a/docs/sources/registry.rst
+++ b/docs/sources/registry.rst
@@ -1,49 +1,40 @@
 Source: registry
-==============
+================
 
-The ``registry`` push source allows push container content from external docker
-registry
+The ``registry`` push source allows the loading of content from a
+`container image registry <https://docs.docker.com/registry/spec/api/>`_.
 
 Supported content types:
 
 * Container images
+* Source container images
 
 
-registry URLs
-------------------
+registry source URLs
+--------------------
 
-Registry source can be obtained by specifying URL + dest tags:
+The base form of a Registry source URL is:
 
-``registry-hostname/namespace/repository:tag:dest-tag1:dest-tag2``
+``registry:image=pullspec1[,pullspec2[,...]]``
 
-For example, referencing a single advisory would look like:
+..where each ``pullspec`` is of the form used by tools such as ``docker pull``,
+with the following restrictions:
 
-``registry.access.redhat.com/ubi8/ubi:8.4-211:latest``
+- the pullspec must reference an image by tag (not digest)
+- the pullspec must always include the registry hostname
 
-To get source with push items populated from external registry you call 
-Source.get like this:
+For example, the following URL accesses a single image by tag:
 
-.. code:
-   Source.get("registry:images_str=registry.access.redhat.com/ubi8/ubi:8.4-211:latest,registry.access.redhat.com/ubi8/ubi:8.3:8.3&dest=ubi-fork&signing_key=01abcdef01234567")
+``registry:image=registry.access.redhat.com/ubi8/ubi:8.4-211``
 
-Code above will produce two push items:
-- dest=ubi-fork:latest
-  src=registry.access.redhat.com/ubi8/ubi:8.4-211
-  dest_signing_key=01abcdef01234567
 
-- dest=ubi-fork:8.3
-  src=registry.access.redhat.com/ubi8/ubi:8.3
-  dest_signing_key=01abcdef01234567
+Authentication
+--------------
 
-Populating registry container push items
-........................................
+If the registry host requires authentication, credentials for the registry
+must be available from ``$HOME/.docker/config.json`` using the same format
+as consumed by ``docker`` and ``podman``.
 
-Each push item is specified by one entry in uris list accepted by source.
-Every URI is inspected as container image which serves as identification
-for source containers. Manifest is also fetched from the specified URL
-to determine which manifest type is served by registry. Registry source
-class requests for manifest list, but anything v2 valid returned by registry
-is accepted
 
 Python API reference
 --------------------

--- a/src/pushsource/_impl/backend/registry_source.py
+++ b/src/pushsource/_impl/backend/registry_source.py
@@ -26,29 +26,34 @@ IMAGE_URI_REGEX = re.compile("https://([^:@]*):(.+)(([^:]:)+)*")
 
 
 class RegistrySource(Source):
-    """Uses URIs of container images as source for push items."""
+    """Uses a container image registry as a source of push items."""
 
-    def __init__(
-        self,
-        image,
-        dest=None,
-        dest_signing_key=None,
-    ):
+    def __init__(self, image, dest=None, dest_signing_key=None):
         """Create a new source.
 
         Parameters:
-            reposs str,
-                Comma separated string with destination(s) repo(s) to fill in for push
-                items created by this source. If omitted, all push items have
-                empty destinations.
+            image (str, list[str])
+                Pull spec(s) of container images, as a list or a comma-separated string.
 
-            image (list[str])
-                String with references to container images with tags+dest tags
-                Format <scheme>:<host>/<namespace>/<repo>:<tag>:<destination_tag>:<destination_tag>
-                Example: https:registry.redhat.io/ubi:8:latest:8:8.1
+                Each pull spec must include a hostname and a tag; referencing images by digest
+                is currently not supported.
 
-            signing_key (list[str])
-                GPG signing key ID(s). If provided, will be signed with those.
+                ``registry.access.redhat.com/ubi8/ubi:8.4-211`` is an example of a valid pull
+                spec.
+
+            dest (str, list[str])
+                If provided, this value will be used to populate :meth:`~pushsource.PushItem.dest`
+                on generated push items.
+
+            dest_signing_key (str, list[str])
+                If provided, this value will be used to populate
+                :meth:`~pushsource.ContainerImagePushItem.dest_signing_key` on generated
+                push items.
+
+                Note that, as each item holds only a single ``dest_signing_key``, using this
+                argument can affect the number of generated push items. For example,
+                providing two keys would produce double the amount of push items as providing
+                a single key.
         """
         self._images = ["https://%s" % x for x in list_argument(image.split(","))]
         if dest:


### PR DESCRIPTION
- add registry to docs/index.rst so it appears under navigation
- fix various incorrect examples, argument names, etc.
- add some details (e.g. authentication) and remove others
- tweak style for consistency