### PR TITLE
registry: fix list handling for some arguments

### DIFF
--- a/src/pushsource/_impl/backend/registry_source.py
+++ b/src/pushsource/_impl/backend/registry_source.py
@@ -50,9 +50,9 @@ class RegistrySource(Source):
             signing_key (list[str])
                 GPG signing key ID(s). If provided, will be signed with those.
         """
-        self._images = ["https://%s" % x for x in list_argument(image.split(","))]
+        self._images = ["https://%s" % x for x in list_argument(image)]
         if dest:
-            self._repos = list_argument(dest.split(","))
+            self._repos = list_argument(dest)
         else:
             self._repos = []
         self._signing_keys = list_argument(dest_signing_key)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -88,9 +88,11 @@ def test_registry_push_items(mocked_inspect, mocked_get_manifest):
     ]
 
     source = RegistrySource(
-        dest="repo1,repo2",
-        image="registry.redhat.io/odf4/mcg-operator-bundle:latest,"
-        "registry.redhat.io/openshift/serverless-1-net-istio-controller-rhel8:1.1",
+        dest=["repo1", "repo2"],
+        image=[
+            "registry.redhat.io/odf4/mcg-operator-bundle:latest",
+            "registry.redhat.io/openshift/serverless-1-net-istio-controller-rhel8:1.1",
+        ],
         dest_signing_key="1234abcde",
     )
     # Eagerly fetch


### PR DESCRIPTION
The point of the list_argument helper is that it will accept both
a true list (preferred in the case of programmatically creating a
Source) and a comma-separated string (preferred in the case of
obtaining source by URL). Calling split() on the input defeats the
purpose.

Fix it to use list_argument appropriately and ensure that each of
the 'list' and 'comma-separated' cases are covered by at least one
test.