### PR TITLE
ci: bump py3 version to 3.9

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install system dependencies
         run: sudo apt-get install -y libkrb5-dev
       - name: Install Tox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox
       - name: Run Tox


### PR DESCRIPTION
Use python 3.9 as the new minimum version for py3.

The motivation for changing it now is to resolve the issue seen in
pip-compile PR #191. The problem is that pip-compile is already using
python 3.9 but other CI configs used 3.8. This is not valid, as the set
of resolved dependencies can differ between the two versions.

It could be solved by either downgrading the python used for pip-compile
or upgrading the python used elsewhere. In this commit I pick the latter
approach, seeing as python 3.9 is readily available on all the py3
target platforms.