### PR TITLE
get_basic_auth should return tuple

### DIFF
--- a/src/pushsource/_impl/utils/containers/request.py
+++ b/src/pushsource/_impl/utils/containers/request.py
@@ -185,7 +185,7 @@ def get_basic_auth(host, home=None):
             config = json.load(f)
             auth = config.get("auths", {}).get(host, {}).get("auth")
             if auth:
-                return base64.b64decode(auth).decode().split(":")
+                return tuple(base64.b64decode(auth).decode().split(":"))
     return None, None
 
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -21,3 +21,4 @@ pyhamcrest
 sphinx
 alabaster
 pidiff
+importlib-resources

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -169,6 +169,10 @@ imagesize==1.3.0 \
     --hash=sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c \
     --hash=sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d
     # via sphinx
+importlib-resources==5.4.0 \
+    --hash=sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45 \
+    --hash=sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b
+    # via -r test-requirements.in
 iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
@@ -665,6 +669,10 @@ wrapt==1.13.3 \
     --hash=sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056 \
     --hash=sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea
     # via astroid
+zipp==3.6.0 \
+    --hash=sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832 \
+    --hash=sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc
+    # via importlib-resources
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.


### PR DESCRIPTION
Also added importlib-resources explicitly to test-requirements.in to
avoid error of unpinned version when installing dependencies (
In --require-hashes mode, all requirements must have their
versionspinned with == )