### PR TITLE
Fetch digests for all manifest types for registry source

### DIFF
--- a/src/pushsource/_impl/backend/registry_source.py
+++ b/src/pushsource/_impl/backend/registry_source.py
@@ -103,7 +103,7 @@ class RegistrySource(Source):
                 self._manifests[source_uri][mtype] = manifest_details
 
             manifest_details = self._manifests[source_uri][mtype]
-            content_type, digest, _ = manifest_details
+            content_type, _, _ = manifest_details
             if content_type not in [MT_S2_V2, MT_S2_V1, MT_S2_V1_SIGNED, MT_S2_LIST]:
                 raise ValueError("Unsupported manifest type:%s" % content_type)
 

--- a/src/pushsource/_impl/backend/registry_source.py
+++ b/src/pushsource/_impl/backend/registry_source.py
@@ -130,7 +130,8 @@ class RegistrySource(Source):
                 for manifest in self._manifests[source_uri].values()
             ],
             media_types=[
-                manifest[0] for manifest in self._manifests[source_uri].values()
+                manifest[0].replace("text/plain", MEDIATYPE_SCHEMA2_V1)
+                for manifest in self._manifests[source_uri].values()
             ],
             tag_specs=[
                 ContainerImageTagPullSpec(

--- a/src/pushsource/_impl/utils/containers/__init__.py
+++ b/src/pushsource/_impl/utils/containers/__init__.py
@@ -3,8 +3,8 @@ from .request import (
     get_manifest,
     api_version_check,
     AuthToken,
-    MT_S2_V1,
-    MT_S2_V1_SIGNED,
-    MT_S2_V2,
-    MT_S2_LIST,
+    MEDIATYPE_SCHEMA2_V1,
+    MEDIATYPE_SCHEMA2_V1_SIGNED,
+    MEDIATYPE_SCHEMA2_V2,
+    MEDIATYPE_SCHEMA2_V2_LIST,
 )

--- a/src/pushsource/_impl/utils/containers/request.py
+++ b/src/pushsource/_impl/utils/containers/request.py
@@ -197,8 +197,8 @@ def _calculate_digest(raw_manifest, manifest):
     if "signatures" in manifest:
         protected = manifest["signatures"][0]["protected"]
         paddings = {0: "", 2: "==", 3: "="}
-        protected = +paddings[len(protected) % 4]
-        unprotected = json.loads(base64.b64decode(unprotected))
+        protected += paddings[len(protected) % 4]
+        unprotected = json.loads(base64.b64decode(protected))
         signed_length = unprotected["formatLength"]
         signed_tail = base64.b64decode(
             unprotected["formatTail"] + paddings[len(unprotected["formatTail"]) % 4]
@@ -227,10 +227,7 @@ def get_manifest(registry, repo, digest, manifest_types=None, token=None):
             headers=headers,
         )
         digest = resp.headers.get("docker-content-digest", None)
-        if not digest and resp.headers.get("Content-Type") in [
-            MEDIATYPE_SCHEMA2_V2,
-            MEDIATYPE_SCHEMA2_V2_LIST,
-        ]:
+        if not digest:
             digest = _calculate_digest(resp.content, resp.json())
 
         content_type = resp.headers.get("Content-Type", None)

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -28,10 +28,10 @@ from pushsource._impl.utils.containers import (
     api_version_check,
     get_manifest,
     inspect,
-    MT_S2_V1,
-    MT_S2_V1_SIGNED,
-    MT_S2_V2,
-    MT_S2_LIST,
+    MEDIATYPE_SCHEMA2_V1,
+    MEDIATYPE_SCHEMA2_V1_SIGNED,
+    MEDIATYPE_SCHEMA2_V2,
+    MEDIATYPE_SCHEMA2_V2_LIST,
 )
 
 from pushsource._impl.utils.containers.request import (
@@ -289,10 +289,20 @@ def test_get_manifest(requests_mock, fake_home):
 @pytest.mark.parametrize(
     "expected_manifest,manifest_type,accept_types, default_should_raise",
     [
-        ({"dummy": "manifest v1"}, MT_S2_V1, [MT_S2_V1, MT_S2_V1_SIGNED], False),
-        ({"dummy": "manifest v1"}, MT_S2_V1, [], False),
-        ({"dummy": "manifest v2"}, MT_S2_V2, [MT_S2_V2], True),
-        ({"dummy": "manifest list"}, MT_S2_LIST, [MT_S2_LIST], True),
+        (
+            {"dummy": "manifest v1"},
+            MEDIATYPE_SCHEMA2_V1,
+            [MEDIATYPE_SCHEMA2_V1, MEDIATYPE_SCHEMA2_V1_SIGNED],
+            False,
+        ),
+        ({"dummy": "manifest v1"}, MEDIATYPE_SCHEMA2_V1, [], False),
+        ({"dummy": "manifest v2"}, MEDIATYPE_SCHEMA2_V2, [MEDIATYPE_SCHEMA2_V2], True),
+        (
+            {"dummy": "manifest list"},
+            MEDIATYPE_SCHEMA2_V2_LIST,
+            [MEDIATYPE_SCHEMA2_V2_LIST],
+            True,
+        ),
     ],
 )
 def test_get_manifest_default(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -13,11 +13,17 @@ from pushsource import (
     ContainerImagePushItem,
     SourceContainerImagePushItem,
 )
+from pushsource._impl.utils.containers import (
+    MT_S2_V1,
+    MT_S2_V1_SIGNED,
+    MT_S2_V2,
+    MT_S2_LIST,
+)
 
 
 MANIFEST_V2SCH2 = {
     "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "mediaType": MT_S2_V2,
     "config": {
         "mediaType": "application/vnd.docker.container.image.v1+json",
         "size": 7023,
@@ -42,9 +48,25 @@ MANIFEST_V2SCH2 = {
     ],
 }
 
+MANIFEST_V1 = {
+    "schemaVersion": 1,
+    "tag": "latest",
+    "name": "odf4/mcg-operator-bundle",
+    "architecture": "amd64",
+    "fsLayers": [
+        {
+            "blobSum": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"
+        },
+        {
+            "blobSum": "sha256:5eb901baf1071ec7a95a08034275fd23d9c776f2f066e18bf9c159c63a21f67a"
+        },
+    ],
+    "history": [],
+}
+
 MANIFEST_V2LIST = {
     "schemaVersion": 2,
-    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+    "mediaType": MT_S2_LIST,
     "manifests": [
         {
             "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
@@ -72,13 +94,43 @@ def test_registry_push_items(mocked_inspect, mocked_get_manifest):
 
     mocked_get_manifest.side_effect = [
         (
-            "application/vnd.docker.distribution.manifest.v1+json",
+            MT_S2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            "application/vnd.docker.distribution.manifest.v1+json",
+            MT_S2_V1,
             "test-digest-1",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-1",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-1",
+            MANIFEST_V2LIST,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-2",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_V1,
+            "test-digest-2",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-2",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-2",
             MANIFEST_V2LIST,
         ),
     ]
@@ -126,13 +178,43 @@ def test_registry_push_items_no_signing_key(mocked_inspect, mocked_get_manifest)
 
     mocked_get_manifest.side_effect = [
         (
-            "application/vnd.docker.distribution.manifest.v1+json",
+            MT_S2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            "application/vnd.docker.distribution.manifest.v1+json",
+            MT_S2_V1,
             "test-digest-1",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-1",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-1",
+            MANIFEST_V2LIST,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-2",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_V1,
+            "test-digest-2",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-2",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-2",
             MANIFEST_V2LIST,
         ),
     ]
@@ -163,13 +245,43 @@ def test_registry_push_items_no_dest(mocked_inspect, mocked_get_manifest):
 
     mocked_get_manifest.side_effect = [
         (
-            "application/vnd.docker.distribution.manifest.v1+json",
+            MT_S2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            "application/vnd.docker.distribution.manifest.v1+json",
+            MT_S2_V1,
             "test-digest-1",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-1",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-1",
+            MANIFEST_V2LIST,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-2",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_V1,
+            "test-digest-2",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-2",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-2",
             MANIFEST_V2LIST,
         ),
     ]
@@ -201,13 +313,43 @@ def test_registry_push_items_multiple_signing_keys(mocked_inspect, mocked_get_ma
 
     mocked_get_manifest.side_effect = [
         (
-            "application/vnd.docker.distribution.manifest.v1+json",
+            MT_S2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            "application/vnd.docker.distribution.manifest.v1+json",
+            MT_S2_V1,
             "test-digest-1",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-1",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-1",
+            MANIFEST_V2LIST,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-2",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_V1,
+            "test-digest-2",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-2",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-2",
             MANIFEST_V2LIST,
         ),
     ]
@@ -304,19 +446,64 @@ def test_source_get(mocked_inspect, mocked_get_manifest):
 
     mocked_get_manifest.side_effect = [
         (
-            "application/vnd.docker.distribution.manifest.v1+json",
+            MT_S2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            "application/vnd.docker.distribution.manifest.list.v2+json",
-            "test-digest-2",
+            MT_S2_V1,
+            "test-digest-1",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-1",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-1",
             MANIFEST_V2LIST,
         ),
         (
-            "application/vnd.docker.distribution.manifest.v2+json",
-            "test-digest-2",
+            MT_S2_V2,
+            "test-digest-1",
             MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_V1,
+            "test-digest-1",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-1",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-1",
+            MANIFEST_V2LIST,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-1",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_V1,
+            "test-digest-1",
+            MANIFEST_V1,
+        ),
+        (
+            MT_S2_V2,
+            "test-digest-1",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MT_S2_LIST,
+            "test-digest-1",
+            MANIFEST_V2LIST,
         ),
     ]
     source = Source.get(

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -14,16 +14,16 @@ from pushsource import (
     SourceContainerImagePushItem,
 )
 from pushsource._impl.utils.containers import (
-    MT_S2_V1,
-    MT_S2_V1_SIGNED,
-    MT_S2_V2,
-    MT_S2_LIST,
+    MEDIATYPE_SCHEMA2_V1,
+    MEDIATYPE_SCHEMA2_V1_SIGNED,
+    MEDIATYPE_SCHEMA2_V2,
+    MEDIATYPE_SCHEMA2_V2_LIST,
 )
 
 
 MANIFEST_V2SCH2 = {
     "schemaVersion": 2,
-    "mediaType": MT_S2_V2,
+    "mediaType": MEDIATYPE_SCHEMA2_V2,
     "config": {
         "mediaType": "application/vnd.docker.container.image.v1+json",
         "size": 7023,
@@ -66,7 +66,7 @@ MANIFEST_V1 = {
 
 MANIFEST_V2LIST = {
     "schemaVersion": 2,
-    "mediaType": MT_S2_LIST,
+    "mediaType": MEDIATYPE_SCHEMA2_V2_LIST,
     "manifests": [
         {
             "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
@@ -94,42 +94,42 @@ def test_registry_push_items(mocked_inspect, mocked_get_manifest):
 
     mocked_get_manifest.side_effect = [
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-1",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-1",
             MANIFEST_V2LIST,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-2",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-2",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-2",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-2",
             MANIFEST_V2LIST,
         ),
@@ -178,42 +178,42 @@ def test_registry_push_items_no_signing_key(mocked_inspect, mocked_get_manifest)
 
     mocked_get_manifest.side_effect = [
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-1",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-1",
             MANIFEST_V2LIST,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-2",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-2",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-2",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-2",
             MANIFEST_V2LIST,
         ),
@@ -245,42 +245,42 @@ def test_registry_push_items_no_dest(mocked_inspect, mocked_get_manifest):
 
     mocked_get_manifest.side_effect = [
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-1",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-1",
             MANIFEST_V2LIST,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-2",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-2",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-2",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-2",
             MANIFEST_V2LIST,
         ),
@@ -313,42 +313,42 @@ def test_registry_push_items_multiple_signing_keys(mocked_inspect, mocked_get_ma
 
     mocked_get_manifest.side_effect = [
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-1",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-1",
             MANIFEST_V2LIST,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-2",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-2",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-2",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-2",
             MANIFEST_V2LIST,
         ),
@@ -436,7 +436,57 @@ def test_registry_push_items_invalid(mocked_inspect, mocked_get_manifest):
     with raises(ValueError) as exc_info:
         with source:
             items = list(source)
-    assert str(exc_info.value) == "Unsupported manifest type:application/json"
+    assert str(exc_info.value) == "Unsupported manifest type: application/json"
+
+
+@patch("pushsource._impl.backend.registry_source.get_manifest")
+@patch("pushsource._impl.backend.registry_source.inspect")
+def test_registry_push_items_tolerate_text_plain(mocked_inspect, mocked_get_manifest):
+    """Registry source raises value error due to invalid push items"""
+
+    mocked_inspect.side_effect = [
+        {"digest": "test-digest-1", "config": {"labels": {"architecture": "amd64"}}},
+        {"digest": "test-digest-2", "config": {"labels": {"architecture": "amd64"}}},
+    ]
+
+    mocked_get_manifest.side_effect = [
+        (
+            "text/plain",
+            "test-digest-1-1",
+            MANIFEST_V1,
+        ),
+        (
+            MEDIATYPE_SCHEMA2_V2,
+            "test-digest-1-2",
+            MANIFEST_V2SCH2,
+        ),
+        (
+            MEDIATYPE_SCHEMA2_V2_LIST,
+            "test-digest-1-3",
+            MANIFEST_V2LIST,
+        ),
+    ]
+    source = RegistrySource(
+        dest="pulp",
+        image="registry.redhat.io/odf4/mcg-operator-bundle:latest",
+        dest_signing_key="1234abcde",
+    )
+    # Eagerly fetch
+    with source:
+        items = list(source)
+    assert len(items) == 1
+    assert items[0].name == "registry.redhat.io/odf4/mcg-operator-bundle:latest", items[
+        0
+    ].name
+    assert items[0].src == "registry.redhat.io/odf4/mcg-operator-bundle:latest"
+    assert items[0].dest_signing_key == "1234abcde"
+    assert items[0].source_tags == ["latest"]
+    assert items[0].dest == ["pulp"]
+    assert [x.media_type for x in items[0].pull_info.digest_specs] == [
+        MEDIATYPE_SCHEMA2_V2_LIST,
+        MEDIATYPE_SCHEMA2_V2,
+        MEDIATYPE_SCHEMA2_V1,
+    ]
 
 
 @patch("pushsource._impl.backend.registry_source.get_manifest")
@@ -446,62 +496,62 @@ def test_source_get(mocked_inspect, mocked_get_manifest):
 
     mocked_get_manifest.side_effect = [
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-1",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-1",
             MANIFEST_V2LIST,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-1",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-1",
             MANIFEST_V2LIST,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_V1,
+            MEDIATYPE_SCHEMA2_V1,
             "test-digest-1",
             MANIFEST_V1,
         ),
         (
-            MT_S2_V2,
+            MEDIATYPE_SCHEMA2_V2,
             "test-digest-1",
             MANIFEST_V2SCH2,
         ),
         (
-            MT_S2_LIST,
+            MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-1",
             MANIFEST_V2LIST,
         ),


### PR DESCRIPTION
In order to allow to push to pulp target, push item has to contain
digests for all manifest types