### PR TITLE
Update tox cov job to generate xml coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands=pidiff pushsource .
 [testenv:cov]
 usedevelop=true
 commands=
-	pytest --cov-report=html --cov=src --cov-fail-under=100 {posargs}
+	pytest --cov-report=html --cov-report=xml --cov=src --cov-fail-under=100 {posargs}
 
 [testenv:cov-travis]
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
Codecov action to upload coverage report was upgraded to v2.
However, the reports were not uploaded correctly as v2 accepts
coverage reports in xml format only. Hence, updating the cov
job in tox to generate coverage reports in xml instead of html.