### PR TITLE
Fixed inspecting v1 images

### DIFF
--- a/src/pushsource/_impl/backend/registry_source.py
+++ b/src/pushsource/_impl/backend/registry_source.py
@@ -111,6 +111,7 @@ class RegistrySource(Source):
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 404:
                         continue
+                    raise e
 
             manifest_details = self._manifests[source_uri][mtype]
             content_type, _, _ = manifest_details

--- a/src/pushsource/_impl/backend/registry_source.py
+++ b/src/pushsource/_impl/backend/registry_source.py
@@ -1,6 +1,8 @@
 import re
 import logging
 
+import requests
+
 from ..source import Source
 from ..model import (
     ContainerImagePushItem,
@@ -98,13 +100,17 @@ class RegistrySource(Source):
             if source_uri not in self._manifests:
                 self._manifests[source_uri] = {}
             if mtype not in self._manifests[source_uri]:
-                manifest_details = get_manifest(
-                    "%s://%s" % (schema, host),
-                    repo,
-                    src_tag,
-                    manifest_types=[mtype],
-                )
-                self._manifests[source_uri][mtype] = manifest_details
+                try:
+                    manifest_details = get_manifest(
+                        "%s://%s" % (schema, host),
+                        repo,
+                        src_tag,
+                        manifest_types=[mtype],
+                    )
+                    self._manifests[source_uri][mtype] = manifest_details
+                except requests.exceptions.HTTPError as e:
+                    if e.response.status_code == 404:
+                        continue
 
             manifest_details = self._manifests[source_uri][mtype]
             content_type, _, _ = manifest_details
@@ -129,33 +135,44 @@ class RegistrySource(Source):
                 )
                 for manifest in self._manifests[source_uri].values()
             ],
-            media_types=[
-                manifest[0].replace("text/plain", MEDIATYPE_SCHEMA2_V1)
-                for manifest in self._manifests[source_uri].values()
-            ],
+            media_types=list(
+                set(
+                    [
+                        manifest[0].replace("text/plain", MEDIATYPE_SCHEMA2_V1)
+                        for manifest in self._manifests[source_uri].values()
+                    ]
+                )
+            ),
             tag_specs=[
                 ContainerImageTagPullSpec(
                     registry=host,
                     repository=repo,
                     tag=src_tag,
-                    media_types=[
-                        manifest[0].replace("text/plain", MEDIATYPE_SCHEMA2_V1)
-                        for manifest in self._manifests[source_uri].values()
-                    ],
+                    media_types=list(
+                        set(
+                            [
+                                manifest[0].replace("text/plain", MEDIATYPE_SCHEMA2_V1)
+                                for manifest in self._manifests[source_uri].values()
+                            ]
+                        )
+                    ),
                 )
             ],
         )
+        # manifest list or v2 sch1
+        labels = self._inspected.get(source_uri, {}).get("config").get(
+            "Labels", {}
+        ) or self._inspected.get(source_uri, {}).get("labels", {})
+        arch = labels.get("architecture")
+
         return klass(
             name=source_uri,
             dest=self._repos,
             dest_signing_key=signing_key,
             src=source_uri,
             source_tags=[src_tag],
-            labels=self._inspected.get(source_uri, {}).get("config").get("Labels", {}),
-            arch=(self._inspected.get(source_uri, {}).get("config", {}) or {})
-            .get("Labels", {})
-            .get("Labels", {})
-            .get("architecture"),
+            labels=labels,
+            arch=arch,
             pull_info=pull_info,
         )
 

--- a/src/pushsource/_impl/utils/containers/request.py
+++ b/src/pushsource/_impl/utils/containers/request.py
@@ -302,11 +302,17 @@ def inspect(registry, repo, digest, token=None):
     token = token or AuthToken()
 
     manifest_type, digest, manifest = get_manifest(
-        registry, repo, digest, manifest_types=[MEDIATYPE_SCHEMA2_V2_LIST], token=token
+        registry, repo, digest, manifest_types=[MEDIATYPE_SCHEMA2_V2], token=token
     )
     if manifest_type == MEDIATYPE_SCHEMA2_V2:
+        print("v2 sch2")
+        print(json.dumps(manifest, indent=2, sort_keys=True, separators=(",", ":")))
         inspected = get_blob(registry, repo, manifest["config"]["digest"]).json()
+        print("INSPECTED")
+        print(json.dumps(inspected, indent=2, sort_keys=True, separators=(",", ":")))
     elif manifest_type == MEDIATYPE_SCHEMA2_V2_LIST:
+        print("v2 sch2 list")
+        print(json.dumps(manifest, indent=2, sort_keys=True, separators=(",", ":")))
         manifest_type, _digest, manifest = get_manifest(
             registry,
             repo,
@@ -315,8 +321,12 @@ def inspect(registry, repo, digest, token=None):
             token=token,
         )
         inspected = get_blob(registry, repo, manifest["config"]["digest"]).json()
+        print("INSPECTED")
+        print(json.dumps(inspected, indent=2, sort_keys=True, separators=(",", ":")))
     else:
-        inspected = {"architecture": manifest["architecture"], "labels": {}}
+        print("v2 sch1")
+        print(json.dumps(manifest, indent=2, sort_keys=True, separators=(",", ":")))
+        inspected = {"architecture": manifest["architecture"], "config": {"Labels": {}}}
     if manifest_type == MEDIATYPE_SCHEMA2_V2 and not inspected.get("config", {}).get(
         "Labels"
     ):

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -512,7 +512,11 @@ def test_inspect_v1(requests_mock):
         json=expected_manifest,
     )
     inspected = inspect("https://fake-registry", "test-repo", "test-tag")
-    assert inspected == {"architecture": "amd64", "labels": {}, "digest": "test-digest"}
+    assert inspected == {
+        "architecture": "amd64",
+        "config": {"Labels": {}},
+        "digest": "test-digest",
+    }
 
 
 def test_inspect_v2(requests_mock):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,6 +6,7 @@ except ImportError:
     from mock import patch, MagicMock
 
 from pytest import raises
+import requests
 
 from pushsource import (
     Source,
@@ -92,6 +93,8 @@ MANIFEST_V2LIST = {
 def test_registry_push_items(mocked_inspect, mocked_get_manifest):
     """Registry source yield push items."""
 
+    response_404 = requests.Response()
+    response_404.status_code = 404
     mocked_get_manifest.side_effect = [
         (
             MEDIATYPE_SCHEMA2_V2,
@@ -103,11 +106,7 @@ def test_registry_push_items(mocked_inspect, mocked_get_manifest):
             "test-digest-1",
             MANIFEST_V1,
         ),
-        (
-            MEDIATYPE_SCHEMA2_V2,
-            "test-digest-1",
-            MANIFEST_V2SCH2,
-        ),
+        requests.exceptions.HTTPError(response=response_404),
         (
             MEDIATYPE_SCHEMA2_V2_LIST,
             "test-digest-1",


### PR DESCRIPTION
Unify inspected output for v1 images. Also tolarted 404 when getting
digest of manifest for containers which have only one type of the
manifests