### PR TITLE
Introduce FilePushItem.display_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+
+- Introduced `FilePushItem.display_order` attribute.
 
 ## [2.13.4] - 2022-01-20
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pushsource",
-    version="2.13.4",
+    version="2.14.0",
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,

--- a/src/pushsource/_impl/backend/staged/staged_files.py
+++ b/src/pushsource/_impl/backend/staged/staged_files.py
@@ -19,6 +19,7 @@ class StagedFilesMixin(StagedBaseMixin):
             src=entry.path,
             description=file_md.attributes.get("description"),
             version=file_md.version,
+            display_order=file_md.order,
             sha256sum=file_md.sha256sum,
             origin=leafdir.topdir,
             dest=[leafdir.dest],

--- a/src/pushsource/_impl/backend/staged/staged_utils.py
+++ b/src/pushsource/_impl/backend/staged/staged_utils.py
@@ -15,6 +15,7 @@ class StagingFileMetadata(object):
     relative_path = attr.ib(type=str)
     sha256sum = attr.ib(type=str)
     version = attr.ib(type=str)
+    order = attr.ib(type=float)
 
 
 @attr.s()
@@ -54,6 +55,7 @@ class StagingMetadata(object):
                 relative_path=entry["relative_path"],
                 sha256sum=entry.get("sha256sum"),
                 version=entry.get("version"),
+                order=entry.get("order"),
             )
             if md.relative_path in file_metadata:
                 raise ValueError(

--- a/src/pushsource/_impl/model/conv.py
+++ b/src/pushsource/_impl/model/conv.py
@@ -115,6 +115,22 @@ def int2str(value):
     return value
 
 
+def convert_maybe(fn):
+    # Given a conversion function, returns a wrapped function which performs
+    # no conversion on None values.
+    #
+    # This is useful for the common case of an optional attribute (default=None),
+    # where a converter should be applied if and only if the default value isn't
+    # being used.
+
+    def out(value):
+        if value is None:
+            return None
+        return fn(value)
+
+    return out
+
+
 in_ = attr.validators.in_
 instance_of = attr.validators.instance_of
 instance_of_str = instance_of(six.string_types)

--- a/src/pushsource/_impl/model/file.py
+++ b/src/pushsource/_impl/model/file.py
@@ -1,6 +1,6 @@
 from .base import PushItem
 from .. import compat_attr as attr
-from .conv import optional_str
+from .conv import optional_str, convert_maybe
 
 
 @attr.s()
@@ -19,3 +19,36 @@ class FilePushItem(PushItem):
     use a version of ``"4.2.33"`` to denote that the file relates
     to OpenShift version 4.2.33.
     """
+
+    display_order = attr.ib(type=float, default=None, converter=convert_maybe(float))
+    """A display order hint associated with the file.
+
+    This value is intended for display purposes only.
+    In a UI presenting a file list, it is suggested that the default order
+    of files should be set by an ascending sort using this value.
+    This provides a method of keeping related files grouped together and
+    presented to users in a logical order.
+
+    .. versionadded:: 2.14.0
+    """
+
+    @display_order.validator
+    def _check_order(self, _, value):
+        if value is None:
+            # OK as field is optional
+            return
+
+        # It has to be a float or convertible to float
+        value = float(value)
+
+        # Enforce some bounds:
+        # - UD has used 99999 as a default "sort at end", so we'll make that the max
+        #   permitted value.
+        # - Pub's default set on push is 0, so most files in practice have that value.
+        # - It's not clear if negative values have been used. However it seems we should
+        #   allow them as otherwise there is no way to arrange for files to sort earlier
+        #   than Pub's historical default.
+        # - The lower bound may as well be symmetrical with the upper bound.
+        # - This check will also filter out NaN.
+        if not (value >= -99999 and value <= 99999):
+            raise ValueError("display_order must be within range -99999 .. 99999")

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -156,6 +156,12 @@ definitions:
                 type: string
                 minLength: 1
 
+            order:
+                # An ordering hint for display purposes
+                type: number
+                minimum: -99999
+                maximum: 99999
+
             attributes:
                 # Additional metadata, differs per content type.
                 $ref: "#/definitions/attributes_any"

--- a/tests/baseline/cases/staged-simple-files.yml
+++ b/tests/baseline/cases/staged-simple-files.yml
@@ -14,6 +14,7 @@ items:
     description: null
     dest:
     - dest1
+    display_order: 1.5
     md5sum: null
     name: test.txt
     origin: {{ src_dir }}/tests/staged/data/simple_files
@@ -28,6 +29,7 @@ items:
     description: ''
     dest:
     - dest2
+    display_order: 3.0
     md5sum: null
     name: some-file.txt
     origin: {{ src_dir }}/tests/staged/data/simple_files
@@ -42,6 +44,7 @@ items:
     description: My wonderful ISO
     dest:
     - dest2
+    display_order: null
     md5sum: null
     name: some-iso
     origin: {{ src_dir }}/tests/staged/data/simple_files

--- a/tests/model/test_file_push_item.py
+++ b/tests/model/test_file_push_item.py
@@ -1,0 +1,13 @@
+import pytest
+
+from pushsource import FilePushItem
+
+
+@pytest.mark.parametrize("value", [float("nan"), -1e17, 1e17])
+def test_display_order_invalid(value):
+    """Verify that ValueError is raised when attempting to set display_order
+    to an out of range value."""
+
+    with pytest.raises(ValueError) as excinfo:
+        FilePushItem(name="item", display_order=value)
+    assert "display_order must be within range -99999 .. 99999" in str(excinfo.value)

--- a/tests/staged/data/simple_files/staged.yaml
+++ b/tests/staged/data/simple_files/staged.yaml
@@ -8,6 +8,7 @@ payload:
     - filename: test.txt
       relative_path: dest1/ISOS/test.txt
       sha256sum: d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8
+      order: 1.5
 
     # example where dest filename does not match filename under staging area
     # (this is not a problem)
@@ -15,6 +16,7 @@ payload:
       relative_path: dest2/FILES/some-file
       sha256sum: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
       version: 1.2.3
+      order: 3
       attributes:
         # empty description is odd, but accepted
         description: ""


### PR DESCRIPTION
This attribute provides a way to manipulate the order in which files are
displayed when presented in a UI.

The field can be populated in staging metadata, at the same level of the
existing 'version' field. This format is the same as Pub apparently
supported prior to migrating to the pushsource library.

The absence of this field from pushsource up to now could be considered
an oversight. Users have managed to get by without it due to some
lower-level tools able to manipulate the relevant Pulp fields directly,
but it would be preferable to fold this into the regular push workflow.