### PR TITLE
Refresh integration with black, drop from 'tox -e static'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 -   repo: https://github.com/ambv/black
-    rev: 026c81b83454f176a9f9253cbfb70be2c159d822
+    rev: 22.1.0
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3.9
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,6 +1,5 @@
 PyYAML
 attrs
-black
 coveralls
 frozenlist2
 jinja2

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -237,34 +237,34 @@ def test_get_manifest(requests_mock, fake_home):
         "sha256:25a01ec9bfd13d405583ef21cdc9ba3182684578ee46248559e75eb59cd73f36"
     )
     expected_manifest = {
-        u"architecture": u"amd64",
-        u"fsLayers": [
+        "architecture": "amd64",
+        "fsLayers": [
             {
-                u"blobSum": u"sha256:b4a41a81fce32bd7fb00ad10e6c73285f937ce2110a619d306ec09f487b40cca"
+                "blobSum": "sha256:b4a41a81fce32bd7fb00ad10e6c73285f937ce2110a619d306ec09f487b40cca"
             },
             {
-                u"blobSum": u"sha256:16dc1f96e3a1bb628be2e00518fec2bb97bd5933859de592a00e2eb7774b6ecf"
+                "blobSum": "sha256:16dc1f96e3a1bb628be2e00518fec2bb97bd5933859de592a00e2eb7774b6ecf"
             },
         ],
-        u"name": u"twaugh/buildroot",
-        u"schemaVersion": 1,
-        u"signatures": [
+        "name": "twaugh/buildroot",
+        "schemaVersion": 1,
+        "signatures": [
             {
-                u"header": {
-                    u"alg": u"ES256",
-                    u"jwk": {
-                        u"crv": u"P-256",
-                        u"kid": u"IT3U:4H7H:YPAL:CSU4:CAC2:MFNW:IWV5:YQNM:547A:FMN4:A4D3:UZAG",
-                        u"kty": u"EC",
-                        u"x": u"WjjIX9YwUSO64Zc5iNMODC4mh9vB-mqgt1uEcE7gLfE",
-                        u"y": u"6fhZlalfi9_cvQd-AwBBwGnidIZKIYVzLsSV6HBR8jA",
+                "header": {
+                    "alg": "ES256",
+                    "jwk": {
+                        "crv": "P-256",
+                        "kid": "IT3U:4H7H:YPAL:CSU4:CAC2:MFNW:IWV5:YQNM:547A:FMN4:A4D3:UZAG",
+                        "kty": "EC",
+                        "x": "WjjIX9YwUSO64Zc5iNMODC4mh9vB-mqgt1uEcE7gLfE",
+                        "y": "6fhZlalfi9_cvQd-AwBBwGnidIZKIYVzLsSV6HBR8jA",
                     },
                 },
-                u"protected": u"eyJmb3JtYXRMZW5ndGgiOjIzMjAsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNi0wNy0xM1QwOToxNjoxMFoifQ",
-                u"signature": u"-dqrUzJ8IbSURO__gkbG2vdzQEbjX32Qv2DjWG3mazTGsRXXgYofr-6VY7lMDUwiOERTD9Te9wyyrALMB7Yt1A",
+                "protected": "eyJmb3JtYXRMZW5ndGgiOjIzMjAsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNi0wNy0xM1QwOToxNjoxMFoifQ",
+                "signature": "-dqrUzJ8IbSURO__gkbG2vdzQEbjX32Qv2DjWG3mazTGsRXXgYofr-6VY7lMDUwiOERTD9Te9wyyrALMB7Yt1A",
             }
         ],
-        u"tag": expected_tag,
+        "tag": expected_tag,
     }
 
     headers = {
@@ -475,34 +475,34 @@ def test_inspect_v1(requests_mock):
         "content-type": "application/vnd.docker.distribution.manifest.v1+json",
     }
     expected_manifest = {
-        u"architecture": u"amd64",
-        u"fsLayers": [
+        "architecture": "amd64",
+        "fsLayers": [
             {
-                u"blobSum": u"sha256:b4a41a81fce32bd7fb00ad10e6c73285f937ce2110a619d306ec09f487b40cca"
+                "blobSum": "sha256:b4a41a81fce32bd7fb00ad10e6c73285f937ce2110a619d306ec09f487b40cca"
             },
             {
-                u"blobSum": u"sha256:16dc1f96e3a1bb628be2e00518fec2bb97bd5933859de592a00e2eb7774b6ecf"
+                "blobSum": "sha256:16dc1f96e3a1bb628be2e00518fec2bb97bd5933859de592a00e2eb7774b6ecf"
             },
         ],
-        u"name": u"twaugh/buildroot",
-        u"schemaVersion": 1,
-        u"signatures": [
+        "name": "twaugh/buildroot",
+        "schemaVersion": 1,
+        "signatures": [
             {
-                u"header": {
-                    u"alg": u"ES256",
-                    u"jwk": {
-                        u"crv": u"P-256",
-                        u"kid": u"IT3U:4H7H:YPAL:CSU4:CAC2:MFNW:IWV5:YQNM:547A:FMN4:A4D3:UZAG",
-                        u"kty": u"EC",
-                        u"x": u"WjjIX9YwUSO64Zc5iNMODC4mh9vB-mqgt1uEcE7gLfE",
-                        u"y": u"6fhZlalfi9_cvQd-AwBBwGnidIZKIYVzLsSV6HBR8jA",
+                "header": {
+                    "alg": "ES256",
+                    "jwk": {
+                        "crv": "P-256",
+                        "kid": "IT3U:4H7H:YPAL:CSU4:CAC2:MFNW:IWV5:YQNM:547A:FMN4:A4D3:UZAG",
+                        "kty": "EC",
+                        "x": "WjjIX9YwUSO64Zc5iNMODC4mh9vB-mqgt1uEcE7gLfE",
+                        "y": "6fhZlalfi9_cvQd-AwBBwGnidIZKIYVzLsSV6HBR8jA",
                     },
                 },
-                u"protected": u"eyJmb3JtYXRMZW5ndGgiOjIzMjAsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNi0wNy0xM1QwOToxNjoxMFoifQ",
-                u"signature": u"-dqrUzJ8IbSURO__gkbG2vdzQEbjX32Qv2DjWG3mazTGsRXXgYofr-6VY7lMDUwiOERTD9Te9wyyrALMB7Yt1A",
+                "protected": "eyJmb3JtYXRMZW5ndGgiOjIzMjAsImZvcm1hdFRhaWwiOiJDbjAiLCJ0aW1lIjoiMjAxNi0wNy0xM1QwOToxNjoxMFoifQ",
+                "signature": "-dqrUzJ8IbSURO__gkbG2vdzQEbjX32Qv2DjWG3mazTGsRXXgYofr-6VY7lMDUwiOERTD9Te9wyyrALMB7Yt1A",
             }
         ],
-        u"tag": tag,
+        "tag": tag,
     }
     requests_mock.register_uri(
         "GET",
@@ -661,8 +661,8 @@ def test_inspect_list(requests_mock):
     )
     inspected = inspect("https://%s" % registry, "test-repo", "test-tag")
     assert inspected == {
-        u"architecture": u"ppc64le",
-        u"config": {u"Labels": {u"architecture": u"ppc64le"}},
+        "architecture": "ppc64le",
+        "config": {"Labels": {"architecture": "ppc64le"}},
         # digest should be calculated from manifest list
         "digest": "sha256:1e89f8bff8d8a6c324ed32ff35ecd457aefec17be856f6bb3a868c2a394dcc88",
     }

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ deps=
 
 [testenv:static]
 commands=
-	black --check .
 	sh -c 'pylint pushsource; test $(( $? & (1|2|4|32) )) = 0'
 
 [testenv:pidiff]


### PR DESCRIPTION
black was previously integrated into both tox and pre-commit.
The version used by tox would be managed by pip-compile.

This causes some issues: if our pip-compile github action updates
to a new version of black which adjusts any formatting, this will cause
CI to fail as it does not automatically run black over all files and
include changes in the commit.

pre-commit.ci on the other hand does support doing exactly that.
Therefore, for black and similar "auto-fixing" tools, it seems better to
leave them solely to pre-commit and not try to include them in tox.

As part of this change, the pre-commit config for black was updated to
ensure pre-commit autoupdates will succeed from this point onwards.