### PR TITLE
Use slots-based classes for pushsource models

### DIFF
--- a/src/pushsource/_impl/compat_attr.py
+++ b/src/pushsource/_impl/compat_attr.py
@@ -6,7 +6,7 @@ import attr
 
 
 def s():
-    kwargs = {"frozen": True}
+    kwargs = {"frozen": True, "slots": True}
     if sys.version_info >= (3,):
         kwargs["kw_only"] = True
     return attr.s(**kwargs)


### PR DESCRIPTION
Some of the commands based on this library are having memory usage
issues. According to my testing of a simple script which loads ~12000
push items, switching to slots-based classes will reduce the memory
usage of pushsource objects by 90%, and the overall memory usage of the
test script by ~33%. Let's do that to relieve the memory pressure.