### PR TITLE
Work around python2 strptime thread-safety bug

### DIFF
--- a/src/pushsource/_impl/model/conv.py
+++ b/src/pushsource/_impl/model/conv.py
@@ -14,6 +14,16 @@ from .. import compat_attr as attr
 LOG = logging.getLogger("pushsource")
 HEX_PATTERN = re.compile(r"^[0-9a-f]+$")
 
+# Work around http://bugs.python.org/issue7980 which is closed "Won't Fix"
+# for python2:
+#
+# If multiple threads in a process do the first call to strptime at once,
+# a crash can occur. Calling strptime once at import time will avoid that
+# condition.
+#
+# TODO: remove me when py2 support is dropped
+datetime.datetime.strptime("", "")
+
 
 def sloppylist(value, elem_converter=None):
     """Accept real lists or comma-separated values, and output a frozen list.


### PR DESCRIPTION
Astonishingly in python2 there is a crash bug in strptime which can
occur if the very first call to the function happens concurrently from
multiple threads. This is https://bugs.python.org/issue7980 which was
closed as "Won't Fix" since the problem is resolved in python3.

It can be worked around by calling the function once at import time,
when we're confident there won't be concurrent calls. Workaround is
inspired by [1].

[1] https://github.com/boto/boto/pull/1940/files