### PR TITLE
docs: fix DirectoryPushItem not reachable in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ A library for accessing push items from various sources.
    sources/errata
    model/base
    model/files
+   model/directory
    model/rpm
    model/modulemd
    model/errata


### PR DESCRIPTION
New pages should be referenced from index.rst, otherwise there is no way
to navigate to them.