### PR TITLE
Allow locating pushsource backends via entry points

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -158,6 +158,25 @@ To implement a backend, follow these steps:
 After following the above steps, instances of your source can be obtained by
 :meth:`~pushsource.Source.get`, in the same manner as backends built-in to the library.
 
+If you’re unsure how to arrange for your call to :class:`~pushsource.Source.register_backend`
+to occur prior to the usage of :meth:`~pushsource.Source.get`, you may declare entry points
+in the ``pushsource`` group; the library will enforce that all modules in this group are
+imported when :meth:`~pushsource.Source.get` is called. This functionality requires
+pushsource 2.17.0 or later.
+
+For example, in setup.py, one may declare:
+
+.. code-block:: python
+
+  entry_points={
+    "pushsource": [
+        # Left-hand side can be anything.
+        # Right-hand side is the name of your module which, on import time,
+        # should perform a call to "Source.register_backend".
+        "mybackend = mylib.my_pushsource_backend",
+    ]
+  },
+
 
 .. _binding:
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def get_requirements():
 
 setup(
     name="pushsource",
-    version="2.16.0",
+    version="2.17.0",
     packages=find_packages("src"),
     package_dir={"": "src"},
     include_package_data=True,

--- a/src/pushsource/_impl/backend/errata_source/errata_source.py
+++ b/src/pushsource/_impl/backend/errata_source/errata_source.py
@@ -536,4 +536,4 @@ class ErrataSource(Source):
                 yield pushitem
 
 
-Source._register_backend_builtin("errata", ErrataSource)
+Source.register_backend("errata", ErrataSource)

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -688,4 +688,4 @@ class KojiSource(Source):
                 yield pushitem
 
 
-Source._register_backend_builtin("koji", KojiSource)
+Source.register_backend("koji", KojiSource)

--- a/src/pushsource/_impl/backend/registry_source.py
+++ b/src/pushsource/_impl/backend/registry_source.py
@@ -183,4 +183,4 @@ class RegistrySource(Source):
                 yield self._push_item_from_registry_uri(uri, key)
 
 
-Source._register_backend_builtin("registry", RegistrySource)
+Source.register_backend("registry", RegistrySource)

--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -177,4 +177,4 @@ class StagedSource(
                 yield pushitem
 
 
-Source._register_backend_builtin("staged", StagedSource)
+Source.register_backend("staged", StagedSource)

--- a/tests/source/test_source_entrypoint.py
+++ b/tests/source/test_source_entrypoint.py
@@ -1,0 +1,50 @@
+from mock import patch
+
+from pushsource import Source
+
+
+def test_loads_entrypoints(monkeypatch):
+    """Source.get ensures 'pushsource' entry points are loaded."""
+
+    # Forcibly set the Source class back to uninitialized state.
+    monkeypatch.setattr(Source, "_BACKENDS", {})
+    monkeypatch.setattr(Source, "_BACKENDS_RESET", {})
+
+    # Let's set up that some custom backends have registered entry points.
+    created1 = []
+    created2 = []
+
+    class Backend1(object):
+        def __init__(self):
+            created1.append(True)
+
+        @classmethod
+        def resolve(cls):
+            Source.register_backend("backend1", Backend1)
+
+    class Backend2(object):
+        def __init__(self):
+            created2.append(True)
+
+        @classmethod
+        def resolve(cls):
+            Source.register_backend("backend2", Backend2)
+
+    with patch("pkg_resources.iter_entry_points") as iter_ep:
+        iter_ep.return_value = [Backend1, Backend2]
+
+        # I should be able to get instances of those two backends
+        assert Source.get("backend1:")
+        assert Source.get("backend2:")
+
+    # It should have found them via the expected entry point group
+    iter_ep.assert_called_once_with("pushsource")
+
+    # Should have created one instance of each
+    assert created1 == [True]
+    assert created2 == [True]
+
+    # These should also be retained over a reset()
+    Source.reset()
+    assert Source.get("backend1:")
+    assert Source.get("backend2:")


### PR DESCRIPTION
This library supports custom backends. A problem can arise: the
backend has to be registered by a call to Source.register_backend, and
if implementing a backend in a library, there may not be any place to
put that call where it's guaranteed to happen by the time it's needed.

Fix this by adding a 'pushsource' entry point group. A library can
define an entry point pointing at a module which calls register_backend.
If so, pushsource library will ensure the module is imported during the
first call to Source.get().