### PR TITLE
Introduce 'direct' backends

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -76,22 +76,35 @@ Available backends
 The pushsource library includes the following backends.
 For detailed information, see the API reference of the associated class.
 
-+----------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
-| Name     | Examples                                                                    | Class                               | Description                                        |
-+==========+=============================================================================+=====================================+====================================================+
-| koji     | ``koji:https://koji.fedoraproject.org?rpm=python3-3.7.5-2.fc31.x86_64.rpm`` | :class:`~pushsource.KojiSource`     | Obtain RPMs, container images and other content    |
-|          |                                                                             |                                     | from a koji server                                 |
-+----------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
-| staged   | ``staged:/mnt/vol/my/staged/content``                                       | :class:`~pushsource.StagedSource`   | Obtain RPMs, files, AMIs and other content from    |
-|          |                                                                             |                                     | locally mounted filesystem                         |
-+----------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
-| registry | ``registry:image=registry.access.redhat.com/ubi8/ubi:latest``               | :class:`~pushsource.RegistrySource` | Obtain images from a container image registry      |
-|          |                                                                             |                                     |                                                    |
-+----------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
-| errata   | ``errata:https://errata.example.com?errata=RHBA-2020:1234``                 | :class:`~pushsource.ErrataSource`   | Obtain RPMs, container images and advisory         |
-|          |                                                                             |                                     | metadata from Errata Tool                          |
-+----------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
-
++--------------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
+| Name         | Examples                                                                    | Class                               | Description                                        |
++==============+=============================================================================+=====================================+====================================================+
+| koji         | ``koji:https://koji.fedoraproject.org?rpm=python3-3.7.5-2.fc31.x86_64.rpm`` | :class:`~pushsource.KojiSource`     | Obtain RPMs, container images and other content    |
+|              |                                                                             |                                     | from a koji server                                 |
++--------------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
+| staged       | ``staged:/mnt/vol/my/staged/content``                                       | :class:`~pushsource.StagedSource`   | Obtain RPMs, files, AMIs and other content from    |
+|              |                                                                             |                                     | locally mounted filesystem                         |
++--------------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
+| registry     | ``registry:image=registry.access.redhat.com/ubi8/ubi:latest``               | :class:`~pushsource.RegistrySource` | Obtain images from a container image registry      |
+|              |                                                                             |                                     |                                                    |
++--------------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
+| errata       | ``errata:https://errata.example.com?errata=RHBA-2020:1234``                 | :class:`~pushsource.ErrataSource`   | Obtain RPMs, container images and advisory         |
+|              |                                                                             |                                     | metadata from Errata Tool                          |
++--------------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
+| file         | ``file:/tmp/file-to-push``                                                  | n/a                                 | Obtain a single file-backed item of various types. |
++--------------+-----------------------------------------------------------------------------+                                     |                                                    |
+| dir          | ``dir:/publish-src?dest=/dest1,/dest2``                                     |                                     |                                                    |
++--------------+-----------------------------------------------------------------------------+                                     |                                                    |
+| rpm          | ``rpm:Downloads/python3-3.7.5-2.fc31.x86_64.rpm?signing_key=a1b2c3``        |                                     | Each backend of this type accepts any arguments    |
++--------------+-----------------------------------------------------------------------------+                                     | of string type documented on the corresponding     |
+| comps        | ``comps:/my/comps.xml?dest=my-target-repo``                                 |                                     | :class:`~pushsource.PushItem` subclass.            |
++--------------+-----------------------------------------------------------------------------+                                     | Arguments of more complex types cannot be used.    |
+| modulemd     | ``modulemd:modules.yaml?name=perl:5.24``                                    |                                     |                                                    |
++--------------+-----------------------------------------------------------------------------+                                     |                                                    |
+| modulemd-src | ``modulemd-src:/some/modulemd.src.txt``                                     |                                     |                                                    |
++--------------+-----------------------------------------------------------------------------+                                     |                                                    |
+| productid    | ``productid:/files/product.pem``                                            |                                     |                                                    |
++--------------+-----------------------------------------------------------------------------+-------------------------------------+----------------------------------------------------+
 
 Processing push items
 ---------------------

--- a/src/pushsource/_impl/backend/__init__.py
+++ b/src/pushsource/_impl/backend/__init__.py
@@ -2,3 +2,4 @@ from .errata_source import ErrataSource
 from .koji_source import KojiSource
 from .staged import StagedSource
 from .registry_source import RegistrySource
+from .direct import DirectSource

--- a/src/pushsource/_impl/backend/direct.py
+++ b/src/pushsource/_impl/backend/direct.py
@@ -1,0 +1,75 @@
+import os
+
+from ..source import Source
+from ..model import (
+    FilePushItem,
+    DirectoryPushItem,
+    CompsXmlPushItem,
+    RpmPushItem,
+    ModuleMdPushItem,
+    ModuleMdSourcePushItem,
+    ProductIdPushItem,
+)
+from ..helpers import list_argument
+
+
+class DirectSource(Source):
+    # A source which directly constructs a single item from given arguments.
+    #
+    # For example:
+    #   - "file:/some/file.txt"
+    #   - will yield a FilePushItem(name="file.txt", src="/some/file.txt")
+    #
+    # Note that this class is not public API. Instances of this source can
+    # be obtained only by URL, using the names registered toward the end
+    # of this file.
+
+    def __init__(self, item):
+        self.__item = item
+
+    def __iter__(self):
+        yield self.__item
+
+    @classmethod
+    def new_source(cls, item_class, url, dest=None, **kwargs):
+        # Make a new DirectSource instance using a specified PushItem
+        # class, along with arguments passed by the caller in the pushsource
+        # URL.
+        #
+        # Example:
+        #
+        # - if someone calls: Source.get("file:/somefile?dest=a,b&foo=bar")
+        # - then:
+        #   - item_class is FilePushItem (see end of this file)
+        #   - url is "/somefile"
+        #   - dest is "a,b"
+        #   - kwargs is {"foo": "bar"}
+
+        # Prepare attributes for constructing the item.
+        #
+        # Note, the attrs listed before update(kwargs) can be
+        # overridden by the caller, while later ones can't.
+        item_attrs = {}
+        item_attrs["origin"] = "direct"
+        item_attrs["name"] = os.path.basename(url)
+        item_attrs.update(kwargs)
+        item_attrs["src"] = url
+        item_attrs["dest"] = sorted(list_argument(dest))
+        item = item_class(**item_attrs)
+        return cls(item)
+
+
+def register(name, item_class):
+    def factory(url, **kwargs):
+        return DirectSource.new_source(item_class, url, **kwargs)
+
+    Source.register_backend(name, factory)
+
+
+register("file", FilePushItem)
+register("dir", DirectoryPushItem)
+register("rpm", RpmPushItem)
+register("comps", CompsXmlPushItem)
+register("modulemd", ModuleMdPushItem)
+register("modulemd-src", ModuleMdSourcePushItem)
+register("productid", ProductIdPushItem)

--- a/tests/baseline/cases/direct-comps.yml
+++ b/tests/baseline/cases/direct-comps.yml
@@ -1,0 +1,21 @@
+# A pushsource library testcase.
+#
+# This file was generated from a template.
+# To regenerate, run test_baseline.py with PUSHSOURCE_UPDATE_BASELINE=1.
+
+# URL of Source to test.
+url: "comps:mycomps.xml?state=WHATEVA"
+
+# Push items generated from above.
+items:
+- CompsXmlPushItem:
+    build: null
+    build_info: null
+    dest: []
+    md5sum: null
+    name: mycomps.xml
+    origin: direct
+    sha256sum: null
+    signing_key: null
+    src: mycomps.xml
+    state: WHATEVA

--- a/tests/baseline/cases/direct-dir.yml
+++ b/tests/baseline/cases/direct-dir.yml
@@ -1,0 +1,22 @@
+# A pushsource library testcase.
+#
+# This file was generated from a template.
+# To regenerate, run test_baseline.py with PUSHSOURCE_UPDATE_BASELINE=1.
+
+# URL of Source to test.
+url: "dir:/srcdir?dest=/destdir"
+
+# Push items generated from above.
+items:
+- DirectoryPushItem:
+    build: null
+    build_info: null
+    dest:
+    - /destdir
+    md5sum: null
+    name: srcdir
+    origin: direct
+    sha256sum: null
+    signing_key: null
+    src: /srcdir
+    state: PENDING

--- a/tests/baseline/cases/direct-file.yml
+++ b/tests/baseline/cases/direct-file.yml
@@ -1,0 +1,26 @@
+# A pushsource library testcase.
+#
+# This file was generated from a template.
+# To regenerate, run test_baseline.py with PUSHSOURCE_UPDATE_BASELINE=1.
+
+# URL of Source to test.
+url: "file:my/great/file.txt?dest=repo1,repo2&name=custom-filename"
+
+# Push items generated from above.
+items:
+- FilePushItem:
+    build: null
+    build_info: null
+    description: null
+    dest:
+    - repo1
+    - repo2
+    display_order: null
+    md5sum: null
+    name: custom-filename
+    origin: direct
+    sha256sum: null
+    signing_key: null
+    src: my/great/file.txt
+    state: PENDING
+    version: null

--- a/tests/baseline/cases/direct-modulemd-src.yml
+++ b/tests/baseline/cases/direct-modulemd-src.yml
@@ -1,0 +1,21 @@
+# A pushsource library testcase.
+#
+# This file was generated from a template.
+# To regenerate, run test_baseline.py with PUSHSOURCE_UPDATE_BASELINE=1.
+
+# URL of Source to test.
+url: "modulemd-src:/some/path/to/modules.src.txt"
+
+# Push items generated from above.
+items:
+- ModuleMdSourcePushItem:
+    build: null
+    build_info: null
+    dest: []
+    md5sum: null
+    name: modules.src.txt
+    origin: direct
+    sha256sum: null
+    signing_key: null
+    src: /some/path/to/modules.src.txt
+    state: PENDING

--- a/tests/baseline/cases/direct-modulemd.yml
+++ b/tests/baseline/cases/direct-modulemd.yml
@@ -1,0 +1,21 @@
+# A pushsource library testcase.
+#
+# This file was generated from a template.
+# To regenerate, run test_baseline.py with PUSHSOURCE_UPDATE_BASELINE=1.
+
+# URL of Source to test.
+url: "modulemd:/some/path/to/modules.yaml?name=my-best-module"
+
+# Push items generated from above.
+items:
+- ModuleMdPushItem:
+    build: null
+    build_info: null
+    dest: []
+    md5sum: null
+    name: my-best-module
+    origin: direct
+    sha256sum: null
+    signing_key: null
+    src: /some/path/to/modules.yaml
+    state: PENDING

--- a/tests/baseline/cases/direct-productid.yml
+++ b/tests/baseline/cases/direct-productid.yml
@@ -1,0 +1,24 @@
+# A pushsource library testcase.
+#
+# This file was generated from a template.
+# To regenerate, run test_baseline.py with PUSHSOURCE_UPDATE_BASELINE=1.
+
+# URL of Source to test.
+url: "productid:/dir/greatest-productid-of-all-time?dest=repo1,repo2,repo3"
+
+# Push items generated from above.
+items:
+- ProductIdPushItem:
+    build: null
+    build_info: null
+    dest:
+    - repo1
+    - repo2
+    - repo3
+    md5sum: null
+    name: greatest-productid-of-all-time
+    origin: direct
+    sha256sum: null
+    signing_key: null
+    src: /dir/greatest-productid-of-all-time
+    state: PENDING

--- a/tests/baseline/cases/direct-rpm.yml
+++ b/tests/baseline/cases/direct-rpm.yml
@@ -1,0 +1,22 @@
+# A pushsource library testcase.
+#
+# This file was generated from a template.
+# To regenerate, run test_baseline.py with PUSHSOURCE_UPDATE_BASELINE=1.
+
+# URL of Source to test.
+url: "rpm:/some/test.rpm?signing_key=a1b2c3&origin=custom-origin"
+
+# Push items generated from above.
+items:
+- RpmPushItem:
+    build: null
+    build_info: null
+    dest: []
+    md5sum: null
+    module_build: null
+    name: test.rpm
+    origin: custom-origin
+    sha256sum: null
+    signing_key: A1B2C3
+    src: /some/test.rpm
+    state: PENDING


### PR DESCRIPTION
These new backends will simply construct and return a single push item
of any file-backed type, for example:

    file:/my/file.txt

...will return a single FilePushItem having src="/my/file.txt" and some
other basic attributes.

These backends are not strictly required as they do not support anything
which is not already supported by the "staged" backend. There's also no
plan at the moment to make them usable from Pub.

The primary motivation here is to make development and testing of
downstream projects less cumbersome. For example, in pubtools-pulp if I
want to test pushing a certain RPM, I should be able to do simply:

    pubtools-pulp-push --source rpm:test.rpm?dest=target-repo ...

... instead of having to create a staging directory, copy/symlink the
test RPM into it and remember to clean it up afterward.