### PR TITLE
Improve AMI billing codes handling [RHELDST-10593]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.9

--- a/src/pushsource/_impl/model/ami.py
+++ b/src/pushsource/_impl/model/ami.py
@@ -102,6 +102,6 @@ class AmiPushItem(PushItem):
     billing_codes = attr.ib(
         type=AmiBillingCodes,
         default=None,
-        validator=optional(instance_of(AmiBillingCodes)),
+        validator=instance_of(AmiBillingCodes),
     )
     """Billing codes associated with this image."""

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -105,6 +105,7 @@ definitions:
         - virtualization
         - volume
         - root_device
+        - billing_codes
 
         additionalProperties: false
 
@@ -226,7 +227,6 @@ definitions:
         # Billing codes for an AMI
         type:
         - object
-        - "null"
         properties:
             name:
                 type: string
@@ -236,7 +236,6 @@ definitions:
                     type: string
         required:
         - name
-        - codes
 
 ###############################################################################
 #  Main schema

--- a/tests/baseline/cases/staged-simple-ami.yml
+++ b/tests/baseline/cases/staged-simple-ami.yml
@@ -9,7 +9,9 @@ url: "staged:{{ src_dir }}/tests/staged/data/simple_ami"
 # Push items generated from above.
 items:
 - AmiPushItem:
-    billing_codes: null
+    billing_codes:
+      codes: []
+      name: FakeBcName
     build: null
     build_info: null
     description: A sample image for testing

--- a/tests/staged/data/simple_ami/staged.yaml
+++ b/tests/staged/data/simple_ami/staged.yaml
@@ -23,3 +23,5 @@ payload:
       type: access
       virtualization: hvm
       volume: gp2
+      billing_codes:
+        name: FakeBcName


### PR DESCRIPTION
This change makes billing_codes attribute in AMI staged
push item required - but codes inside billing_codes are allowed to
be empty or completely omitted.

This will allow creation of AMI push-item without billing-codes but
we can still use billing_codes.name that comprises AMI image name.