### PR TITLE
Add missing parameter "repo"

### DIFF
--- a/src/pushsource/_impl/utils/containers/request.py
+++ b/src/pushsource/_impl/utils/containers/request.py
@@ -267,6 +267,7 @@ def get_blob(registry, repo, digest, token=None):
         auth_token=token,
         retry_404=True,
         credentials=auth,
+        repo=repo,
     )
     resp.raise_for_status()
     return resp


### PR DESCRIPTION
Add the parameter "repo" while calling registry_request in get_blob,
otherwise "scope" may not be added while requesting token.

Refers to CLOUDDST-12357