### PR TITLE
Add caching for a few fields which often have duplicates [RHELDST-11377]

### DIFF
--- a/src/pushsource/_impl/model/base.py
+++ b/src/pushsource/_impl/model/base.py
@@ -2,9 +2,11 @@ import hashlib
 import os
 import logging
 
+import six
 from frozenlist2 import frozenlist
 
 from .. import compat_attr as attr
+from .cache import TinyCache
 from .conv import (
     md5str,
     sha256str,
@@ -94,7 +96,11 @@ class PushItem(object):
     If the push item does not represent a file, this will generally be omitted.
     """
 
-    dest = attr.ib(type=list, default=attr.Factory(frozenlist), converter=frozenlist)
+    dest = attr.ib(
+        type=list,
+        default=attr.Factory(frozenlist),
+        converter=TinyCache(frozenlist, frozenlist),
+    )
     """Destination of this push item.
 
     The meaning of "dest" differs depending on the source used and its configuration.
@@ -123,7 +129,9 @@ class PushItem(object):
         :meth:`with_checksums`
     """
 
-    origin = attr.ib(type=str, default=None, validator=optional_str)
+    origin = attr.ib(
+        type=str, default=None, validator=optional_str, converter=TinyCache(str)
+    )
     """A string representing the origin of this push item.
 
     The "origin" field is expected to record some info on how this push item
@@ -149,7 +157,10 @@ class PushItem(object):
         return KojiBuildInfo._from_nvr(self.build)
 
     signing_key = attr.ib(
-        type=str, default=None, validator=optional_str, converter=upper_if_str
+        type=str,
+        default=None,
+        validator=optional_str,
+        converter=TinyCache(six.string_types, upper_if_str),
     )
     """If this push item was GPG signed, this should be an identifier for the
     signing key used.

--- a/src/pushsource/_impl/model/cache.py
+++ b/src/pushsource/_impl/model/cache.py
@@ -1,0 +1,92 @@
+class TinyCache(object):
+    """A tiny specialized cache capable of reusing (very) recent values.
+
+    These caches are meant to be used as attr field converters, with one
+    cache created per cacheable field.
+
+    Whenever a new value for that field is about to be saved, the cache
+    will first be consulted. If the new value is equal to the last couple
+    of values for the same field (across all constructed objects), then
+    the value from cache will be returned instead.
+
+    The caching strategy may seem odd, but it works out well due to the
+    way push items tend to be constructed in practice. For example: it
+    is common for every RPM in a push to use the same signing key. In
+    that scenario, this cache will allow every signing_key field to
+    reference exactly the same string rather than a copy.
+    Similarly, it is common to construct many items having the same
+    'dest'.
+
+    Compared to a more conventional cache storing some values in a list
+    or dict, this has the advantage that the cache size is always fixed
+    and very small, meaning it is very unlikely that the cache overhead
+    can exceed the savings from using the cache.
+
+    Here are some measurements of the impact of this caching on a real
+    data set of ~52,000 push items:
+
+    +------------------+-----------+---------------+
+    | case             | mem (KiB) | total objects |
+    +==================+===========+===============+
+    | no cache (min)   | 103928    | 261182        |
+    | no cache (max)   | 120096    | 261420        |
+    | tiny cache (min) | 98472     | 252582        |
+    | tiny cache (max) | 109608    | 252466        |
+    +------------------+-----------+---------------+
+
+    We create about 10,000 less python objects in total and reduce
+    push item memory usage between 5% .. 13%.
+
+    It is of course only safe for use on immutable types.
+    """
+
+    __slots__ = ("last1", "last2", "cache_type", "converter")
+
+    def __init__(self, cache_type, converter=lambda x: x):
+        """Construct a cache.
+
+        Arguments:
+            cache_type
+                Type(s) used for an isinstance() check.
+
+                Only values of this type are eligible for caching;
+                anything else will be returned as-is.
+
+            converter
+                A callable to convert input values before caching.
+
+                TinyCache is meant to be used as an attrs field converter.
+                This argument can be used to chain onto another converter
+                where needed.
+        """
+        # Last two values. Note, the number of lastN here could be anything.
+        # It was determined by experiment that N=2 is slightly better than
+        # N=1.
+        self.last1 = None
+        self.last2 = None
+        self.cache_type = cache_type
+        self.converter = converter
+
+    def __call__(self, value):
+        value = self.converter(value)
+
+        if not isinstance(value, self.cache_type):
+            # Not eligible for caching
+            return value
+
+        # deref these here because we have no synchronization
+        # across threads and we don't want this to change between
+        # our equality check and returning it.
+        # Note: this is thread-safe, but multi-threaded code
+        # might lower the cache hit rate.
+        last1 = self.last1
+        last2 = self.last2
+
+        if value == last1:
+            return last1
+        if value == last2:
+            return last2
+
+        self.last1 = last2
+        self.last2 = value
+        return value

--- a/tests/model/test_field_caching.py
+++ b/tests/model/test_field_caching.py
@@ -1,0 +1,28 @@
+from pushsource import PushItem
+
+
+def test_fields_cached():
+    # Try making two items with similar fields.
+    # Note: the weird string construction here is meant to defeat
+    # the built-in python logic of interning string literals since
+    # that would defeat the purpose of the test...
+    item1 = PushItem(
+        name="item1", origin="some-origin", dest=["a", "b", "c"], signing_key="a1b2c3d4"
+    )
+    item2 = PushItem(
+        name="item2",
+        origin="-".join(["some", "origin"]),
+        dest=["a", "b", "c"],
+        signing_key="2".join(["a1b", "c3d4"]),
+    )
+
+    # Field values should be not only equal...
+    for item in (item1, item2):
+        assert item.origin == "some-origin"
+        assert item.dest == ["a", "b", "c"]
+        assert item.signing_key == "A1B2C3D4"
+
+    # ...but they should also be *identical*
+    assert item1.origin is item2.origin
+    assert item1.dest is item2.dest
+    assert item1.signing_key is item2.signing_key


### PR DESCRIPTION
For push item sources such as staged and errata, fields like
'signing_key' and 'dest' will often have the same value across most or
even all of the loaded objects. This leads to tens of thousands of
copies of the same strings, wasting a bit of memory.

We can achieve some modest savings by caching/sharing values across
items. It is safe, since the shared values are immutable. This commit
implements such sharing for a handful of fields.

A few different caching approaches were tried here, but for most of
them the overhead of the cache exceeded the memory saved. In the end the
chosen strategy was to cache only the last couple of values per field,
which seems odd but works due to the typical usage patterns of push
items (constructing a lot of similar items at once). An included doc
string has some actual numbers on the savings.