### PR TITLE
Add io2 and gp3 EC2 volume types

### DIFF
--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -70,7 +70,9 @@ definitions:
                 enum:
                 - standard
                 - gp2
+                - gp3
                 - io1
+                - io2
                 - st1
                 - sc1
 


### PR DESCRIPTION
There are new volume types available at AWS: https://aws.amazon.com/ebs/volume-types/ , these should be added.