### PR TITLE
Fix multiple levels of 'src' existence polling

### DIFF
--- a/src/pushsource/_impl/source.py
+++ b/src/pushsource/_impl/source.py
@@ -42,6 +42,15 @@ class SourceWrapper(object):
     # This feature is disabled by default and can be enabled with
     # environment variables
     def __init__(self, delegate):
+
+        if isinstance(delegate, SourceWrapper):
+            # It is common for multiple layers of Source to be constructed,
+            # but we don't want multiple layers of SourceWrapper since it
+            # would double up the src polling logic while achieving nothing
+            # useful. So, if we are being asked to wrap a SourceWrapper,
+            # we'll pick out the underlying delegate instead and wrap that.
+            delegate = delegate.__delegate
+
         self.__delegate = delegate
 
     def __iter__(self):


### PR DESCRIPTION
297ad8bdbac33d760 added polling for the existence of files in the 'src'
attribute before yielding items.

However, the way it was implemented would tend to cause multiple
levels of polling because sources could be wrapped with a SourceWrapper
more than once. This is a common case in practice as several sources
used by Pub are built by wrapping the source underneath (e.g. 'brew'
source is just a 'koji' source with some arguments prefilled, and both
layers would end up with a SourceWrapper, both of which would run the
src polling logic).

Fix it up by a minor tweak to avoid creating multiple layers of
SourceWrapper.