### PR TITLE
Supress warning log when not checking for file's existence

### DIFF
--- a/src/pushsource/_impl/helpers.py
+++ b/src/pushsource/_impl/helpers.py
@@ -172,11 +172,12 @@ def wait_exist(path, timeout, poll_rate):
         if os.path.exists(path):
             break
         if i == max_attempts:
-            LOG.warning(
-                "File %s is missing after %s seconds",
-                path,
-                timeout,
-            )
+            if max_attempts > 0:
+                LOG.warning(
+                    "File %s is missing after %s seconds",
+                    path,
+                    timeout,
+                )
             break
         LOG.info(
             "Waiting for %s seconds for file %s to appear",


### PR DESCRIPTION
If it's not desirable to check for file's existence (when timeout is 0),
the warning log notifying that the file doesn't exist shouldn't be
printed.

This fix unbreaks some pub integration tests which are now failing due
to new logs being introduced.