### PR TITLE
Make pushsource compatible with attrs >=22.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes requirements.in
 #
-attrs==21.4.0 \
-    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
-    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
+attrs==22.1.0 \
+    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
+    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
     # via
     #   -r requirements.in
     #   jsonschema

--- a/src/pushsource/_impl/model/erratum_fixup.py
+++ b/src/pushsource/_impl/model/erratum_fixup.py
@@ -66,7 +66,8 @@ class AttrsRenamer(object):
                     attr_kwargs[argname] = getattr(old_attr, argname)
                 elif (
                     six.PY3
-                    and argname in inspect.signature(old_attr.__class__.__init__).parameters.keys()
+                    and argname
+                    in inspect.signature(old_attr.__class__.__init__).parameters.keys()
                 ):
                     attr_kwargs[argname] = None
             new_attr = old_attr.__class__(**attr_kwargs)

--- a/src/pushsource/_impl/model/erratum_fixup.py
+++ b/src/pushsource/_impl/model/erratum_fixup.py
@@ -25,6 +25,9 @@ Unfortunately, that does not work because the attrs library internally
 tries to eval some code of the form "<attr_name> = ...", which will never
 work if the name is a keyword.
 """
+import inspect
+
+import six
 
 
 class AttrsRenamer(object):
@@ -61,6 +64,11 @@ class AttrsRenamer(object):
             ]:
                 if hasattr(old_attr, argname):
                     attr_kwargs[argname] = getattr(old_attr, argname)
+                elif (
+                    six.PY3
+                    and argname in inspect.signature(old_attr.__class__.__init__).parameters.keys()
+                ):
+                    attr_kwargs[argname] = None
             new_attr = old_attr.__class__(**attr_kwargs)
 
             self._attrs_by_name[new_name] = new_attr

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,9 +16,9 @@ astroid==2.11.7 \
     # via
     #   pidiff
     #   pylint
-attrs==21.4.0 \
-    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
-    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
+attrs==22.1.0 \
+    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
+    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
     # via
     #   -r requirements.in
     #   -r test-requirements.in


### PR DESCRIPTION
In attrs version 22.1.0 the deprecated 'cmp' attribute was removed. This
has broken the dependency for pushsource, because the attributes are no
longer correctly initialized. AttrsRenamer checks whether a required
__init__ parameter is present in the created Attribute, and constructs a
new Attribute with only the present parameters. This is done with the
assumption that some constructor parameters will be removed in the
future, and this check would prevent the object construction from
breaking. In the attrs version 22.1.0 the deprecated "cmp" attribute was
removed and so it is no longer passed as an argument to the constructor.
This causes an error, since this argument is still expected in the
constructor, even though it doesn't do anything [1]. So let's also check
if the argument is in the constructor signature, and if it is, set it as
None. The method inspect.signature is only available in Python 3. This
is not an issue, since the attrs version that breaks pushsource (22.1.0)
also dropped Python 2.7 support, meaning that the breaking behavior may
only happen on Python 3.

[1] https://github.com/python-attrs/attrs/blob/main/src/attr/_make.py#L2504