### PR TITLE
Added v2ch2_list schema type for inspect

### DIFF
--- a/src/pushsource/_impl/utils/containers/request.py
+++ b/src/pushsource/_impl/utils/containers/request.py
@@ -308,7 +308,7 @@ def inspect(registry, repo, digest, token=None):
     token = token or AuthToken()
 
     manifest_type, digest, manifest = get_manifest(
-        registry, repo, digest, manifest_types=[MEDIATYPE_SCHEMA2_V2], token=token
+        registry, repo, digest, manifest_types=[MEDIATYPE_SCHEMA2_V2_LIST, MEDIATYPE_SCHEMA2_V2], token=token
     )
     if manifest_type == MEDIATYPE_SCHEMA2_V2:
         inspected = get_blob(registry, repo, manifest["config"]["digest"]).json()

--- a/src/pushsource/_impl/utils/containers/request.py
+++ b/src/pushsource/_impl/utils/containers/request.py
@@ -308,7 +308,11 @@ def inspect(registry, repo, digest, token=None):
     token = token or AuthToken()
 
     manifest_type, digest, manifest = get_manifest(
-        registry, repo, digest, manifest_types=[MEDIATYPE_SCHEMA2_V2_LIST, MEDIATYPE_SCHEMA2_V2], token=token
+        registry,
+        repo,
+        digest,
+        manifest_types=[MEDIATYPE_SCHEMA2_V2_LIST, MEDIATYPE_SCHEMA2_V2],
+        token=token,
     )
     if manifest_type == MEDIATYPE_SCHEMA2_V2:
         inspected = get_blob(registry, repo, manifest["config"]["digest"]).json()


### PR DESCRIPTION
When there's no v2ch2 manfiest inspect fails on 404, therefore
v2ch2_list manifest was added as backup schema