### PR TITLE
Only poll for existence if item source is a file

### DIFF
--- a/src/pushsource/_impl/source.py
+++ b/src/pushsource/_impl/source.py
@@ -77,7 +77,11 @@ class SourceWrapper(object):
 
         generator = self.__delegate.__iter__()
         for item in generator:
-            if not hasattr(item, "src") or not item.src:
+            if (
+                not hasattr(item, "src")
+                or not item.src
+                or not item.src.startswith("/")
+            ):
                 yield item
             else:
                 wait_exist(item.src, timeout, poll_rate)
@@ -150,7 +154,11 @@ class Source(object):
             # call any method.
             # resolve vs load is for different versions of pkg_resources.
             # Result is assigned to a var to avoid a pylint warning.
-            _ = ep.resolve() if hasattr(ep, "resolve") else ep.load(require=False)
+            _ = (
+                ep.resolve()
+                if hasattr(ep, "resolve")
+                else ep.load(require=False)
+            )
 
     @classmethod
     def get(cls, source_url, **kwargs):
@@ -249,7 +257,9 @@ class Source(object):
         # in which case the next block should kick in. If the backend is a partial
         # created by us, this info may be available in __pushsource_accepts_url.
         # See commentary a bit later where this is set.
-        accepts_url = getattr(klass, "__pushsource_accepts_url", "url" in sig.args)
+        accepts_url = getattr(
+            klass, "__pushsource_accepts_url", "url" in sig.args
+        )
 
         if accepts_url and parsed.path is not query:
             # If the source accepts a url argument, then the 'path' part

--- a/src/pushsource/_impl/source.py
+++ b/src/pushsource/_impl/source.py
@@ -77,11 +77,7 @@ class SourceWrapper(object):
 
         generator = self.__delegate.__iter__()
         for item in generator:
-            if (
-                not hasattr(item, "src")
-                or not item.src
-                or not item.src.startswith("/")
-            ):
+            if not hasattr(item, "src") or not item.src or not item.src.startswith("/"):
                 yield item
             else:
                 wait_exist(item.src, timeout, poll_rate)
@@ -154,11 +150,7 @@ class Source(object):
             # call any method.
             # resolve vs load is for different versions of pkg_resources.
             # Result is assigned to a var to avoid a pylint warning.
-            _ = (
-                ep.resolve()
-                if hasattr(ep, "resolve")
-                else ep.load(require=False)
-            )
+            _ = ep.resolve() if hasattr(ep, "resolve") else ep.load(require=False)
 
     @classmethod
     def get(cls, source_url, **kwargs):
@@ -257,9 +249,7 @@ class Source(object):
         # in which case the next block should kick in. If the backend is a partial
         # created by us, this info may be available in __pushsource_accepts_url.
         # See commentary a bit later where this is set.
-        accepts_url = getattr(
-            klass, "__pushsource_accepts_url", "url" in sig.args
-        )
+        accepts_url = getattr(klass, "__pushsource_accepts_url", "url" in sig.args)
 
         if accepts_url and parsed.path is not query:
             # If the source accepts a url argument, then the 'path' part


### PR DESCRIPTION
Recently, a polling mechanism was introducted to pushsource to check if a file exists before continueing the push. This was necessary because mounted volumes (where the files are located) are snapmirrored and there's a time delay before new files are propagated to the snapmirror volumes. There is an unwanted side effect where all push items are checked, even those that don't contain a file in their source (namely container images that contain the image URL instead). This is undesirable behavior, because image URL is not a file and thus will never be found on disk. This bug significantly slows the pushes, since the items will be polled until timeout is reached. Fix it by only checking push item sources that start with "/", indicating that they are local files.

Refers to CLOUDDST-16707