### PR TITLE
Fix compatibility with tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps=
     -rtest-requirements.txt
 commands=
 	pytest -vv  {posargs:./}
-whitelist_externals=sh
+allowlist_externals=sh
 
 [testenv:py27]
 deps=
@@ -28,13 +28,6 @@ commands=pidiff pushsource .
 usedevelop=true
 commands=
 	pytest --cov-report=html --cov-report=xml --cov=src --cov-fail-under=100 {posargs}
-
-[testenv:cov-travis]
-passenv = TRAVIS TRAVIS_*
-usedevelop=true
-commands=
-	pytest --cov=src {posargs}
-	coveralls
 
 [testenv:docs]
 use_develop=true


### PR DESCRIPTION
The term 'whitelist' must be replaced with 'allowlist' for compatibility with tox >= 4.0.0.