### PR TITLE
Limit kw_only usage to attrs 18.2 or newer

### DIFF
--- a/src/pushsource/_impl/compat_attr.py
+++ b/src/pushsource/_impl/compat_attr.py
@@ -5,9 +5,12 @@ import attr
 # Wrappers for attr module to deal with some incompatibilities between versions
 
 
+ATTR_VERSION = tuple(int(x) for x in attr.__version__.split(".")[0:2])
+
+
 def s():
     kwargs = {"frozen": True, "slots": True}
-    if sys.version_info >= (3,):
+    if sys.version_info >= (3,) and ATTR_VERSION >= (18, 2):
         kwargs["kw_only"] = True
     return attr.s(**kwargs)
 


### PR DESCRIPTION
Apart from python2, the kw_only keyword argument for `attr.s()` throws `TypeError: attrs() got an unexpected keyword argument 'kw_only'` also on python3 installations using version of attrs module older than 18.2. RHEL-8 ships attrs in version 17.4, hence the argument needs to be excluded there as well.