### PR TITLE
EXDSP-1781: Allow KojiSource to retrieve VMIPushItems

### DIFF
--- a/docs/sources/koji.rst
+++ b/docs/sources/koji.rst
@@ -11,6 +11,7 @@ Supported content types:
 * RPMs
 * container images (with operator manifests if applicable)
 * modulemd YAML streams (yum repo metadata)
+* virtual machine images
 
 Note that many features of the koji source requires having koji's volume(s) mounted
 locally.
@@ -77,6 +78,21 @@ Push items produced in this case may include:
 - :class:`~pushsource.OperatorManifestPushItem` - if images have attached operator
   manifest archives
 
+Accessing virtual machine images
+...............................
+
+Use the ``vmi_build`` parameter to request virtual machine images from one or
+more builds. Builds can be specified by NVR. Builds should be produced by
+`Image Builder`_ or should use compatible metadata.
+
+``koji:https://koji.fedoraproject.org/kojihub?vmi_build=fedora-azure-37-1.7``
+
+Push items produced in this case may include:
+
+- :class:`~pushsource.VMIPushItem` - one for each available image
+- :class:`~pushsource.VHDPushItem` - for Azure VHD images.
+- :class:`~pushsource.AmiPushItem` - for AMI raw images.
+
 Setting the destination for push items
 ......................................
 
@@ -110,3 +126,4 @@ Python API reference
 
 
 .. _OSBS: https://osbs.readthedocs.io/
+.. _Image Builder: https://www.osbuild.org/guides/image-builder-service/image-builder-koji.html

--- a/tests/koji/test_koji_vmi.py
+++ b/tests/koji/test_koji_vmi.py
@@ -1,0 +1,228 @@
+import os
+
+from pytest import raises
+
+from pushsource import (
+    Source,
+    AmiPushItem,
+    VHDPushItem,
+    VMIPushItem,
+    AmiRelease,
+    VMIRelease,
+)
+
+
+def test_koji_vmi_notfound(fake_koji):
+    """koji source referencing nonexistent VMI build will fail."""
+
+    source = Source.get("koji:https://koji.example.com/?vmi_build=notexist-1.2.3")
+    with raises(ValueError) as exc_info:
+        list(source)
+
+    assert "Virtual machine image build not found in koji: notexist-1.2.3" in str(
+        exc_info.value
+    )
+
+
+def test_koji_not_vmi_invalid(fake_koji, koji_dir):
+    """Koji source referencing an invalid build will fail."""
+
+    source = Source.get(
+        "koji:https://koji.example.com/?vmi_build=foobuild-1.0-1", basedir=koji_dir
+    )
+
+    fake_koji.build_data[1234] = {
+        "id": 1234,
+        "name": "foobuild",
+        "version": "1.0",
+        "release": "1",
+        "nvr": "foobuild-1.0-1",
+        "completion_time": "2022-12-20 12:30:25",
+    }
+    fake_koji.build_data["foobuild-1.0-1"] = fake_koji.build_data[1234]
+
+    with raises(ValueError) as exc_info:
+        list(source)
+
+    assert (
+        "Build foobuild-1.0-1 not recognized as a virtual machine image build"
+        in str(exc_info.value)
+    )
+
+
+def test_koji_not_vmi_container(fake_koji, koji_dir):
+    """Koji source referencing a container will fail."""
+
+    source = Source.get(
+        "koji:https://koji.example.com/?vmi_build=foobuild-1.0-1", basedir=koji_dir
+    )
+
+    # Container image build
+    fake_koji.build_data[1234] = {
+        "id": 1234,
+        "name": "foobuild",
+        "version": "1.0",
+        "release": "1",
+        "nvr": "foobuild-1.0-1",
+        "completion_time": "2022-12-20 12:30:25",
+        "extra": {"typeinfo": {"image": {}}, "container_koji_task_id": "container"},
+    }
+    fake_koji.build_data["foobuild-1.0-1"] = fake_koji.build_data[1234]
+    with raises(ValueError) as exc_info:
+        list(source)
+
+    assert "The build foobuild-1.0-1 is for container images." in str(exc_info.value)
+
+
+def test_koji_vmis(fake_koji, koji_dir):
+    """Koji source yields requested Virtual Machine Images."""
+
+    name = "foobuild"
+    version = "1.0"
+    release = "20230110.sp.22"
+    nvr = "%s-%s-%s" % (name, version, release)
+
+    source = Source.get(
+        "koji:https://koji.example.com/?vmi_build=%s" % nvr, basedir=koji_dir
+    )
+
+    # It should not have done anything yet (lazy loading)
+    assert not fake_koji.last_url
+
+    # Insert some data
+    fake_koji.build_data[1234] = {
+        "id": 1234,
+        "name": name,
+        "version": version,
+        "release": release,
+        "nvr": nvr,
+        "completion_time": "2022-12-20 12:30:25",
+        "extra": {"typeinfo": {"image": {}}},
+    }
+    fake_koji.build_data[nvr] = fake_koji.build_data[1234]
+
+    imgs = {
+        "foo-1.0-20230110.sp.22.img": "generic",
+        "foo-1.0-20230110.sp.22.raw.xz": "raw-xz",
+        "foo-1.0-20230110.sp.22.vhd.xz": "vhd-compressed",
+    }
+
+    archives = []
+    for fname, tname in imgs.items():
+        archives.append(
+            {
+                "btype": "image",
+                "filename": fname,
+                "checksum": "00000000000000000000000000000000",
+                "extra": {"image": {"arch": "x86_64"}},
+                "type_name": tname,
+                "build_id": 1234,
+                "nvr": nvr,
+            }
+        )
+
+    fake_koji.insert_archives(archives=archives, build_nvr=nvr)
+
+    # Eagerly fetch
+    items = list(source)
+
+    # It should have returned only valid push items for the modules
+    assert len(items) == 2
+
+    items = sorted(items, key=lambda pi: pi.name)
+
+    klasses = [AmiPushItem, VHDPushItem]
+    index = 0
+    imgs.pop("foo-1.0-20230110.sp.22.img")  # Invalid image filtered out by KojiSource
+
+    for klass in klasses:
+        fname = sorted(list(imgs.keys()))[index]
+
+        rel_klass = AmiRelease if klass == AmiPushItem else VMIRelease
+
+        rel_obj = rel_klass(
+            arch="x86_64",
+            date="2022-12-20",
+            product="FOOBUILD",
+            version=version,
+            respin=0,
+        )
+
+        assert items[index] == klass(
+            name=fname,
+            state="PENDING",
+            src=os.path.join(
+                koji_dir, "packages/foobuild/1.0/20230110.sp.22/images/%s" % fname
+            ),
+            dest=[],
+            description="",
+            md5sum="00000000000000000000000000000000",
+            sha256sum=None,
+            origin=None,
+            build=nvr,
+            signing_key=None,
+            release=rel_obj,
+        )
+        index += 1
+
+
+def test_koji_vmi_compound_product_name(fake_koji, koji_dir):
+    source = Source.get(
+        "koji:https://koji.example.com/?vmi_build=foobuild-azure-1.0-1",
+        basedir=koji_dir,
+    )
+
+    # Insert some data
+    fake_koji.build_data[1234] = {
+        "id": 1234,
+        "name": "foobuild-azure",
+        "version": "1.0",
+        "release": "1",
+        "nvr": "foobuild-azure-1.0-1",
+        "completion_time": "2022-12-20 12:30:25",
+        "extra": {"typeinfo": {"image": {}}},
+    }
+    fake_koji.build_data["foobuild-azure-1.0-1"] = fake_koji.build_data[1234]
+
+    fake_koji.insert_archives(
+        archives=[
+            {
+                "btype": "image",
+                "filename": "foo-azure-1.0-1.raw.xz",
+                "checksum": "00000000000000000000000000000000",
+                "extra": {"image": {"arch": "x86_64"}},
+                "type_name": "raw-xz",
+                "build_id": 1234,
+                "nvr": "foobuild-azure-1.0-1",
+            }
+        ],
+        build_nvr="foobuild-azure-1.0-1",
+    )
+
+    # Eagerly fetch
+    items = list(source)
+
+    # For product the name "foobuild-azure" should become only "foobuild" in uppercase
+    rel_obj = AmiRelease(
+        arch="x86_64",
+        date="2022-12-20",
+        product="FOOBUILD",
+        version="1.0",
+        respin=1,
+    )
+
+    assert items[0] == AmiPushItem(
+        name="foo-azure-1.0-1.raw.xz",
+        state="PENDING",
+        src=os.path.join(
+            koji_dir, "packages/foobuild-azure/1.0/1/images/foo-azure-1.0-1.raw.xz"
+        ),
+        dest=[],
+        description="",
+        md5sum="00000000000000000000000000000000",
+        sha256sum=None,
+        origin=None,
+        build="foobuild-azure-1.0-1",
+        signing_key=None,
+        release=rel_obj,
+    )


### PR DESCRIPTION
This PR allows `pushsource` to load Virtual Machine Images through `KojiSource`.

The VM images will come as a `VMIPushItem` or as its subclasses: `AmiPushItem` / `VHDPushItem`.

To load the VM images the application may use:

```{python}
from pushsource import Source, VMIPushItem

with Source.get('koji:https://koji.fedoraproject.org/kojihub?vmi_build=img1,img2,...') as source:
    for item in source:
        ...  # do something
```

**NOTE:** As Koji doesn't contain all metadata for `VMIPushItem` and its subclasses it only load the common values which can be found on it. Missing information as well as specific data required for Azure or AWS may be fetched from an external service.

Refers to EXDSP-1781