### PR TITLE
Poll for staged content

### DIFF
--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -143,7 +143,9 @@ class StagedSource(
         # Apply wait only if topdir mtime is less than X seconds older than current time.
         # The idea is "Only apply wait if the staging dir was recently modified".
         # The lower the value, the fewer pushes will wait,the higher the probability of missing data
-        apply_wait_topdir_age = int(os.getenv("PUSHSOURCE_APPLY_WAIT_TOPDIR_AGE") or "0")
+        apply_wait_topdir_age = int(
+            os.getenv("PUSHSOURCE_APPLY_WAIT_TOPDIR_AGE") or "0"
+        )
 
         if not os.path.exists(topdir):
             LOG.info(

--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -3,6 +3,8 @@ import threading
 import logging
 import itertools
 import functools
+import time
+from datetime import datetime
 
 import yaml
 import json
@@ -135,6 +137,39 @@ class StagedSource(
 
     def _push_items_for_topdir(self, topdir):
         LOG.info("Checking files in: %s", topdir)
+
+        # How long to wait until staged data are synced to snapmirrored volume.
+        wait_time = int(os.getenv("PUSHSOURCE_SRC_POLL_TIMEOUT") or "0")
+        # Apply wait only if topdir mtime is less than X seconds older than current time.
+        # The idea is "Only apply wait if the staging dir was recently modified".
+        # The lower the value, the fewer pushes will wait,the higher the probability of missing data
+        apply_wait_topdir_age = int(os.getenv("PUSHSOURCE_APPLY_WAIT_TOPDIR_AGE") or "0")
+
+        if not os.path.exists(topdir):
+            LOG.info(
+                "Directory '%s' doesn't exist yet. Waiting for %s seconds.",
+                topdir,
+                wait_time,
+            )
+            time.sleep(wait_time)
+        elif int(os.path.getmtime(topdir)) > int(time.time()) - apply_wait_topdir_age:
+            LOG.info(
+                "Directory '%s' has mtime %s+00:00, being less than "
+                "%s seconds old. Waiting for %s seconds.",
+                topdir,
+                datetime.utcfromtimestamp(int(os.path.getmtime(topdir))).isoformat(),
+                apply_wait_topdir_age,
+                wait_time,
+            )
+            time.sleep(wait_time)
+        else:
+            LOG.info(
+                "Directory '%s' has mtime %s+00:00, being more than "
+                "%s seconds old. Skipping the wait.",
+                topdir,
+                datetime.utcfromtimestamp(int(os.path.getmtime(topdir))).isoformat(),
+                apply_wait_topdir_age,
+            )
 
         metadata = self._load_metadata(topdir)
 

--- a/tests/staged/test_staged_simple_rpm.py
+++ b/tests/staged/test_staged_simple_rpm.py
@@ -1,4 +1,6 @@
 import os
+import logging
+from mock import patch
 
 from pushsource import Source, RpmPushItem
 
@@ -44,3 +46,154 @@ def test_staged_simple_rpm(caplog):
     nonrpm_path = os.path.join(staged_dir, "dest1/RPMS/not-an-rpm.txt")
     msg = "Unexpected non-RPM %s (ignored)" % nonrpm_path
     assert msg in caplog.messages
+
+
+@patch.dict(
+    "os.environ",
+    {"PUSHSOURCE_SRC_POLL_TIMEOUT": "60"},
+)
+@patch("pushsource._impl.backend.staged.staged_source.time.sleep")
+@patch(
+    "pushsource._impl.backend.staged.staged_source.StagedSource._push_items_for_leafdir"
+)
+@patch("pushsource._impl.backend.staged.staged_source.StagedSource._load_metadata")
+@patch("pushsource._impl.backend.staged.staged_source.os.path.exists")
+def test_staged_simple_rpm_wait_nonexistent_path(
+    mock_path_exists,
+    mock_load_metadata,
+    mock_push_items_for_leafdir,
+    mock_sleep,
+    caplog,
+):
+    caplog.set_level(logging.INFO)
+    mock_path_exists.return_value = False
+    staged_dir = os.path.join(DATADIR, "simple_rpm")
+    source = Source.get("staged:" + staged_dir)
+
+    list(source)
+
+    mock_sleep.assert_called_once()
+    mock_load_metadata.assert_called_once()
+    mock_push_items_for_leafdir.assert_called()
+
+    assert "doesn't exist yet. Waiting for 60 seconds." in caplog.records[1].message
+
+
+@patch.dict(
+    "os.environ",
+    {"PUSHSOURCE_SRC_POLL_TIMEOUT": "60", "PUSHSOURCE_APPLY_WAIT_TOPDIR_AGE": "100"},
+)
+@patch("pushsource._impl.backend.staged.staged_source.time.time")
+@patch("pushsource._impl.backend.staged.staged_source.time.sleep")
+@patch(
+    "pushsource._impl.backend.staged.staged_source.StagedSource._push_items_for_leafdir"
+)
+@patch("pushsource._impl.backend.staged.staged_source.StagedSource._load_metadata")
+@patch("pushsource._impl.backend.staged.staged_source.os.path.exists")
+@patch("pushsource._impl.backend.staged.staged_source.os.path.getmtime")
+def test_staged_simple_rpm_recent_dir_mtime_wait(
+    mock_getmtime,
+    mock_path_exists,
+    mock_load_metadata,
+    mock_push_items_for_leafdir,
+    mock_sleep,
+    mock_time,
+    caplog,
+):
+    caplog.set_level(logging.INFO)
+    mock_time.return_value = 1000
+    mock_getmtime.return_value = 950
+    mock_path_exists.return_value = True
+    staged_dir = os.path.join(DATADIR, "simple_rpm")
+    source = Source.get("staged:" + staged_dir)
+
+    list(source)
+
+    mock_sleep.assert_called_once()
+    mock_load_metadata.assert_called_once()
+    mock_push_items_for_leafdir.assert_called()
+
+    assert (
+        "has mtime 1970-01-01T00:15:50+00:00, being less than 100 seconds old. "
+        "Waiting for 60 seconds." in caplog.records[1].message
+    )
+
+
+@patch.dict(
+    "os.environ",
+    {"PUSHSOURCE_SRC_POLL_TIMEOUT": "60", "PUSHSOURCE_APPLY_WAIT_TOPDIR_AGE": "100"},
+)
+@patch("pushsource._impl.backend.staged.staged_source.time.time")
+@patch("pushsource._impl.backend.staged.staged_source.time.sleep")
+@patch(
+    "pushsource._impl.backend.staged.staged_source.StagedSource._push_items_for_leafdir"
+)
+@patch("pushsource._impl.backend.staged.staged_source.StagedSource._load_metadata")
+@patch("pushsource._impl.backend.staged.staged_source.os.path.exists")
+@patch("pushsource._impl.backend.staged.staged_source.os.path.getmtime")
+def test_staged_simple_rpm_older_dir_skip_wait(
+    mock_getmtime,
+    mock_path_exists,
+    mock_load_metadata,
+    mock_push_items_for_leafdir,
+    mock_sleep,
+    mock_time,
+    caplog,
+):
+    caplog.set_level(logging.INFO)
+    mock_time.return_value = 1000
+    mock_getmtime.return_value = 700
+    mock_path_exists.return_value = True
+    staged_dir = os.path.join(DATADIR, "simple_rpm")
+    source = Source.get("staged:" + staged_dir)
+
+    list(source)
+
+    mock_sleep.assert_not_called()
+    mock_load_metadata.assert_called_once()
+    mock_push_items_for_leafdir.assert_called()
+
+    assert (
+        "has mtime 1970-01-01T00:11:40+00:00, being more than 100 seconds old. "
+        "Skipping the wait." in caplog.records[1].message
+    )
+
+
+@patch.dict(
+    "os.environ",
+    {"PUSHSOURCE_SRC_POLL_TIMEOUT": "60", "PUSHSOURCE_APPLY_WAIT_TOPDIR_AGE": "0"},
+)
+@patch("pushsource._impl.backend.staged.staged_source.time.time")
+@patch("pushsource._impl.backend.staged.staged_source.time.sleep")
+@patch(
+    "pushsource._impl.backend.staged.staged_source.StagedSource._push_items_for_leafdir"
+)
+@patch("pushsource._impl.backend.staged.staged_source.StagedSource._load_metadata")
+@patch("pushsource._impl.backend.staged.staged_source.os.path.exists")
+@patch("pushsource._impl.backend.staged.staged_source.os.path.getmtime")
+def test_staged_simple_rpm_age_check_disabled(
+    mock_getmtime,
+    mock_path_exists,
+    mock_load_metadata,
+    mock_push_items_for_leafdir,
+    mock_sleep,
+    mock_time,
+    caplog,
+):
+    caplog.set_level(logging.INFO)
+    mock_time.return_value = 1000
+    mock_getmtime.return_value = 1000
+    mock_path_exists.return_value = True
+    staged_dir = os.path.join(DATADIR, "simple_rpm")
+    source = Source.get("staged:" + staged_dir)
+
+    list(source)
+
+    mock_sleep.assert_not_called()
+    mock_load_metadata.assert_called_once()
+    mock_push_items_for_leafdir.assert_called()
+
+    assert (
+        "has mtime 1970-01-01T00:16:40+00:00, being more than 0 seconds old. "
+        "Skipping the wait." in caplog.records[1].message
+    )


### PR DESCRIPTION
Staged content is checked before the main polling mechanism, meaning that PushStaged code fails unless the staged content is present in the snapmirror. Add the polling mechanism to staged content. If staged path doesn't exist in the mounted volume, its existence will be polled until it appears. In this scenario it is safe to assume that the staged content is new and up-to-date.

In rare cases, existing staged content may be altered and pushed again. Since pushsource cannot know if the altered content has been propagated to snapmirror, it has to wait the full poll_timeout period to be safe. Thus, if the content already exists on the volume, wait the full period to ensure it's up to date.

This implementation assumes that push-staged is ran with only one path. Otherwise, the code will wait the full poll_timeout for each path, which is unnecessary and time inefficient. Running push-staged with multiple paths is apparently not a real use-case, so it should be fine in 99% of cases.

Refers to CLOUDDST-17045