### PR TITLE
Introduce pub source backend [RHELDST-7514]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- n/a
+### Added
+- Introduced new source backend - `pub` that is used for extracting push items from Pub service
 
 ## [2.24.0] - 2023-01-17
 

--- a/docs/sources/pub.rst
+++ b/docs/sources/pub.rst
@@ -1,0 +1,30 @@
+Source: pub
+==============
+
+The ``pub`` push source allows the loading of content from an instance of Pub.
+
+Supported content types:
+
+* AMIs
+
+
+pub source URLs
+------------------
+
+The base form of an pub source URL is:
+
+``pub:pub-url?task_id=100[,200[,...]]``
+
+For example, referencing a single task would look like:
+
+``pub:https://pub.example.com?task_id=1234``
+
+The provided Pub URL should be the base URL of the service,
+and not any specific API endpoint.
+
+Python API reference
+--------------------
+
+.. autoclass:: pushsource.PubSource
+   :members:
+   :special-members: __init__

--- a/src/pushsource/__init__.py
+++ b/src/pushsource/__init__.py
@@ -35,4 +35,5 @@ from pushsource._impl.backend import (
     KojiSource,
     StagedSource,
     RegistrySource,
+    PubSource,
 )

--- a/src/pushsource/_impl/__init__.py
+++ b/src/pushsource/_impl/__init__.py
@@ -1,5 +1,5 @@
 from . import utils
 
 from .source import Source, SourceUrlError
-from .backend import ErrataSource
+from .backend import ErrataSource, PubSource
 from .model import PushItem, ErratumPushItem

--- a/src/pushsource/_impl/backend/__init__.py
+++ b/src/pushsource/_impl/backend/__init__.py
@@ -3,3 +3,4 @@ from .koji_source import KojiSource
 from .staged import StagedSource
 from .registry_source import RegistrySource
 from .direct import DirectSource
+from .pub_source import PubSource

--- a/src/pushsource/_impl/backend/pub_source/__init__.py
+++ b/src/pushsource/_impl/backend/pub_source/__init__.py
@@ -1,0 +1,1 @@
+from .pub_source import PubSource

--- a/src/pushsource/_impl/backend/pub_source/pub_client.py
+++ b/src/pushsource/_impl/backend/pub_source/pub_client.py
@@ -1,0 +1,63 @@
+import json
+import logging
+import os
+import threading
+
+
+import requests
+from more_executors import Executors
+
+
+LOG = logging.getLogger("pushsource.pub_client")
+
+
+class PubClient(object):
+    def __init__(self, threads, url, **retry_args):
+        self._executor = (
+            Executors.thread_pool(name="pushsource-pub-client", max_workers=threads)
+            .with_map(self._unpack_response)
+            .with_retry(**retry_args)
+            .with_cancel_on_shutdown()
+        )
+        self._url = url
+        self._tls = threading.local()
+
+    def shutdown(self):
+        self._executor.shutdown(True)
+
+    def _unpack_response(self, response):
+        try:
+            response.raise_for_status()
+            out = response.json()
+        except json.JSONDecodeError:
+            # do not treat invalid json as fatal error
+            out = None
+        return out
+
+    @property
+    def _session(self):
+        if not hasattr(self._tls, "session"):
+            LOG.debug(
+                "Creating requests Session for client of Pub service: %s", self._url
+            )
+            self._tls.session = requests.Session()
+        return self._tls.session
+
+    def _do_request(self, **kwargs):
+        return self._session.request(**kwargs)
+
+    def get_ami_json_f(self, task_id):
+        """
+        Returns Future[dict|list] holding json obj with AMI push items returned from Pub for given task id.
+        """
+        endpoint = "pub/task"
+        url_ending = "log/images.json"
+        params = {"format": "raw"}
+        url = os.path.join(self._url, endpoint, str(task_id), url_ending)
+
+        LOG.info("Requesting Pub service for %s of task: %s", url_ending, str(task_id))
+        ft = self._executor.submit(
+            self._do_request, method="GET", url=url, params=params
+        )
+
+        return ft

--- a/src/pushsource/_impl/backend/pub_source/pub_source.py
+++ b/src/pushsource/_impl/backend/pub_source/pub_source.py
@@ -1,0 +1,106 @@
+import logging
+from concurrent import futures
+
+from more_executors import Executors
+
+from ...helpers import (
+    as_completed_with_timeout_reset,
+    force_https,
+    list_argument,
+    try_int,
+)
+from ...model import AmiPushItem
+from ...source import Source
+from .pub_client import PubClient
+
+LOG = logging.getLogger("pushsource")
+
+
+class PubSource(Source):
+    """Uses push item list from Pub as the source of push items."""
+
+    def __init__(
+        self,
+        url,
+        task_id,
+        threads=4,
+        timeout=60 * 60 * 4,
+    ):
+        """Create a new source.
+
+        Parameters:
+            url (src)
+                Base URL of Pub Tool, e.g. "http://pub.example.com",
+                "https://pub.example.com:8123".
+
+            task_id (int, str, list[str], list[int])
+                Task ID(s) to be used as push item source.
+                If a single string is given, multiple IDs may be
+                comma-separated.
+
+            threads (int)
+                Number of threads used for concurrent queries to Pub.
+
+            timeout (int)
+                Number of seconds after which an error is raised, if no progress is
+                made during queries to Pub.
+        """
+
+        self._url = force_https(url)
+        self._task_ids = self._validate_task_ids(
+            [try_int(x) for x in list_argument(task_id)]
+        )
+        self._client = PubClient(threads=threads, url=self._url)
+        self._timeout = timeout
+        # This executor doesn't use retry because pub-client executor already does that.
+        self._executor = Executors.thread_pool(
+            name="pushsource-pub", max_workers=threads
+        ).with_cancel_on_shutdown()
+
+    def _validate_task_ids(self, task_ids):
+        out = []
+        for task_id in task_ids:
+            if isinstance(task_id, int):
+                out.append(task_id)
+            else:
+                LOG.warning("Invalid Pub task ID: %s", task_id)
+        return out
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._client.shutdown()
+        self._executor.shutdown(True)
+
+    def _push_items_from_ami_json(self, json_obj):
+        out = []
+
+        try:
+            push_items = AmiPushItem._from_data(json_obj)
+            out.extend(list_argument(push_items))
+        except KeyError:
+            LOG.warning("Cannot parse AMI push item/s: %s", str(json_obj))
+
+        return out
+
+    def __iter__(self):
+        # Get json Pub responses for all task ids
+        json_fs = [self._client.get_ami_json_f(task_id) for task_id in self._task_ids]
+
+        # Convert them to lists of push items
+        push_items_fs = []
+        for f in futures.as_completed(json_fs, timeout=self._timeout):
+            push_items_fs.append(
+                self._executor.submit(self._push_items_from_ami_json, f.result())
+            )
+
+        completed_fs = as_completed_with_timeout_reset(
+            push_items_fs, timeout=self._timeout
+        )
+        for f in completed_fs:
+            for pushitem in f.result():
+                yield pushitem
+
+
+Source.register_backend("pub", PubSource)

--- a/tests/baseline/cases/staged-simple-ami-bc.yml
+++ b/tests/baseline/cases/staged-simple-ami-bc.yml
@@ -20,6 +20,7 @@ items:
     dest:
     - dest1
     ena_support: true
+    image_id: null
     md5sum: null
     name: fake-image.raw
     origin: {{ src_dir }}/tests/staged/data/simple_ami_with_bc

--- a/tests/baseline/cases/staged-simple-ami.yml
+++ b/tests/baseline/cases/staged-simple-ami.yml
@@ -16,6 +16,7 @@ items:
     dest:
     - dest1
     ena_support: true
+    image_id: null
     md5sum: null
     name: fake-image.raw
     origin: {{ src_dir }}/tests/staged/data/simple_ami

--- a/tests/pub/data/100/images.json
+++ b/tests/pub/data/100/images.json
@@ -1,0 +1,37 @@
+[
+  {
+    "ami": "ami-fake-100", 
+    "billing_codes": {
+      "codes": [
+        "bp-fake"
+      ], 
+      "name": "Hourly2"
+    }, 
+    "description": "Provided by Red Hat, Inc.", 
+    "dest": [
+      "me-south-1-hourly"
+    ], 
+    "ena_support": true, 
+    "name": "RHEL-SAP-8.4.0_HVM-20230109-x86_64-0-Hourly2-GP2", 
+    "origin": "/fake/path/aws", 
+    "region": "me-south-1", 
+    "release": {
+      "arch": "x86_64", 
+      "base_product": "RHEL", 
+      "base_version": null, 
+      "date": "20230109", 
+      "product": "SAP", 
+      "respin": 0, 
+      "type": null, 
+      "variant": "BaseOS", 
+      "version": "8.4.0"
+    }, 
+    "root_device": "/dev/sda1", 
+    "src": "/fake/path/aws/me-south-1-hourly/AWS_IMAGES/rhel-sap-ec2-8.4-20220802.sp.10.x86_64.raw", 
+    "sriov_net_support": "simple", 
+    "state": "PUSHED", 
+    "type": "hourly", 
+    "virtualization": "hvm", 
+    "volume": "gp2"
+  }
+]

--- a/tests/pub/data/123456/images.json
+++ b/tests/pub/data/123456/images.json
@@ -1,0 +1,37 @@
+[
+    {
+      "ami": "ami-fake-123456", 
+      "billing_codes": {
+        "codes": [
+          "bp-fake"
+        ], 
+        "name": "Hourly2"
+      }, 
+      "description": "Provided by Red Hat, Inc.", 
+      "dest": [
+        "sa-east-1-hourly"
+      ], 
+      "ena_support": true, 
+      "name": "RHEL-SAP-8.4.0_HVM-20230109-x86_64-0-Hourly2-GP2", 
+      "origin": "/fake/path/aws/", 
+      "region": "sa-east-1", 
+      "release": {
+        "arch": "x86_64", 
+        "base_product": "RHEL", 
+        "base_version": null, 
+        "date": "20230109", 
+        "product": "SAP", 
+        "respin": 0, 
+        "type": null, 
+        "variant": "BaseOS", 
+        "version": "8.4.0"
+      }, 
+      "root_device": "/dev/sda1", 
+      "src": "/fake/path/aws/sa-east-1-hourly/AWS_IMAGES/rhel-sap-ec2-8.4-20220802.sp.10.x86_64.raw", 
+      "sriov_net_support": "simple", 
+      "state": "PUSHED", 
+      "type": "hourly", 
+      "virtualization": "hvm", 
+      "volume": "gp2"
+    }
+]

--- a/tests/pub/data/200/images.json
+++ b/tests/pub/data/200/images.json
@@ -1,0 +1,72 @@
+[
+  {
+    "ami": "ami-fake-200-A", 
+    "billing_codes": {
+      "codes": [
+        "bp-fake"
+      ], 
+      "name": "Hourly2"
+    }, 
+    "description": "Provided by Red Hat, Inc.", 
+    "dest": [
+      "us-east-1-hourly"
+    ], 
+    "ena_support": true, 
+    "name": "RHEL-SAP-8.4.0_HVM-20230109-x86_64-0-Hourly2-GP2", 
+    "origin": "/fake/path/aws/", 
+    "region": "us-east-1", 
+    "release": {
+      "arch": "x86_64", 
+      "base_product": "RHEL", 
+      "base_version": null, 
+      "date": "20230109", 
+      "product": "SAP", 
+      "respin": 0, 
+      "type": null, 
+      "variant": "BaseOS", 
+      "version": "8.4.0"
+    }, 
+    "root_device": "/dev/sda1", 
+    "src": "/fake/path/aws/us-east-1-hourly/AWS_IMAGES/rhel-sap-ec2-8.4-20220802.sp.10.x86_64.raw", 
+    "sriov_net_support": "simple", 
+    "state": "PUSHED", 
+    "type": "hourly", 
+    "virtualization": "hvm", 
+    "volume": "gp2"
+  }, 
+  {
+    "ami": "ami-fake-200-B", 
+    "billing_codes": {
+      "codes": [
+        "bp-fake"
+      ], 
+      "name": "Hourly2"
+    }, 
+    "description": "Provided by Red Hat, Inc.", 
+    "dest": [
+      "me-central-1-hourly"
+    ], 
+    "ena_support": true, 
+    "name": "RHEL-SAP-8.4.0_HVM-20230109-x86_64-0-Hourly2-GP2", 
+    "origin": "/fake/path/aws/", 
+    "region": "me-central-1", 
+    "release": {
+      "arch": "x86_64", 
+      "base_product": "RHEL", 
+      "base_version": null, 
+      "date": "20230109", 
+      "product": "SAP", 
+      "respin": 0, 
+      "type": null, 
+      "variant": "BaseOS", 
+      "version": "8.4.0"
+    }, 
+    "root_device": "/dev/sda1", 
+    "src": "/fake/path/aws/me-central-1-hourly/AWS_IMAGES/rhel-sap-ec2-8.4-20220802.sp.10.x86_64.raw", 
+    "sriov_net_support": "simple", 
+    "state": "PUSHED", 
+    "type": "hourly", 
+    "virtualization": "hvm", 
+    "volume": "gp2"
+  }
+]

--- a/tests/pub/test_pub_amis.py
+++ b/tests/pub/test_pub_amis.py
@@ -1,0 +1,300 @@
+import json
+import logging
+import os
+
+import pytest
+import requests
+
+from pushsource import AmiBillingCodes, AmiPushItem, AmiRelease, Source
+
+DATAPATH = os.path.join(os.path.dirname(__file__), "data")
+
+
+def make_response(task_id):
+    with open(os.path.join(DATAPATH, str(task_id), "images.json")) as f:
+        return json.load(f)
+
+
+def test_get_ami_push_items_single_task(requests_mock):
+    """
+    Tests getting push item from one Pub task.
+    """
+    # test setup
+    task_id = 123456
+    pub_url = "https://pub.example.com"
+    request_url = os.path.join(
+        pub_url, "pub/task", str(task_id), "log/images.json?format=raw"
+    )
+
+    requests_mock.register_uri("GET", request_url, json=make_response(task_id))
+
+    # request push items from source
+    with Source.get("pub:%s" % pub_url, task_id=task_id) as source:
+        push_items = [item for item in source]
+
+    # there should be exactly one  push item
+    assert len(push_items) == 1
+
+    # with following content
+    assert push_items == [
+        AmiPushItem(
+            name="RHEL-SAP-8.4.0_HVM-20230109-x86_64-0-Hourly2-GP2",
+            state="PENDING",
+            src="/fake/path/aws/sa-east-1-hourly/AWS_IMAGES/rhel-sap-ec2-8.4-20220802.sp.10.x86_64.raw",
+            dest=["sa-east-1-hourly"],
+            md5sum=None,
+            sha256sum=None,
+            origin="/fake/path/aws/",
+            build=None,
+            build_info=None,
+            signing_key=None,
+            release=AmiRelease(
+                product="SAP",
+                date="20230109",
+                arch="x86_64",
+                respin=0,
+                version="8.4.0",
+                base_product="RHEL",
+                base_version=None,
+                variant="BaseOS",
+                type=None,
+            ),
+            type="hourly",
+            region="sa-east-1",
+            virtualization="hvm",
+            volume="gp2",
+            root_device="/dev/sda1",
+            description="Provided by Red Hat, Inc.",
+            sriov_net_support="simple",
+            ena_support=True,
+            billing_codes=AmiBillingCodes(name="Hourly2", codes=["bp-fake"]),
+            image_id="ami-fake-123456",
+        )
+    ]
+
+
+def test_get_ami_push_items_multiple_tasks(requests_mock):
+    """
+    Tests getting push items for multiple Pub tasks.
+    """
+    # test setup
+    task_ids = "123456,100,200"
+    pub_url = "https://pub.example.com"
+
+    for task_id in task_ids.split(","):
+        request_url = os.path.join(
+            pub_url, "pub/task", task_id, "log/images.json?format=raw"
+        )
+        requests_mock.register_uri("GET", request_url, json=make_response(task_id))
+
+    # request push items from push source
+    with Source.get("pub:%s" % pub_url, task_id=task_ids) as source:
+        push_items = [item for item in source]
+
+    # there should be 4 items
+    assert len(push_items) == 4
+    # with following content
+    assert sorted(push_items, key=lambda x: x.image_id) == [
+        AmiPushItem(
+            name="RHEL-SAP-8.4.0_HVM-20230109-x86_64-0-Hourly2-GP2",
+            state="PENDING",
+            src="/fake/path/aws/me-south-1-hourly/AWS_IMAGES/rhel-sap-ec2-8.4-20220802.sp.10.x86_64.raw",
+            dest=["me-south-1-hourly"],
+            md5sum=None,
+            sha256sum=None,
+            origin="/fake/path/aws",
+            build=None,
+            build_info=None,
+            signing_key=None,
+            release=AmiRelease(
+                product="SAP",
+                date="20230109",
+                arch="x86_64",
+                respin=0,
+                version="8.4.0",
+                base_product="RHEL",
+                base_version=None,
+                variant="BaseOS",
+                type=None,
+            ),
+            type="hourly",
+            region="me-south-1",
+            virtualization="hvm",
+            volume="gp2",
+            root_device="/dev/sda1",
+            description="Provided by Red Hat, Inc.",
+            sriov_net_support="simple",
+            ena_support=True,
+            billing_codes=AmiBillingCodes(name="Hourly2", codes=["bp-fake"]),
+            image_id="ami-fake-100",
+        ),
+        AmiPushItem(
+            name="RHEL-SAP-8.4.0_HVM-20230109-x86_64-0-Hourly2-GP2",
+            state="PENDING",
+            src="/fake/path/aws/sa-east-1-hourly/AWS_IMAGES/rhel-sap-ec2-8.4-20220802.sp.10.x86_64.raw",
+            dest=["sa-east-1-hourly"],
+            md5sum=None,
+            sha256sum=None,
+            origin="/fake/path/aws/",
+            build=None,
+            build_info=None,
+            signing_key=None,
+            release=AmiRelease(
+                product="SAP",
+                date="20230109",
+                arch="x86_64",
+                respin=0,
+                version="8.4.0",
+                base_product="RHEL",
+                base_version=None,
+                variant="BaseOS",
+                type=None,
+            ),
+            type="hourly",
+            region="sa-east-1",
+            virtualization="hvm",
+            volume="gp2",
+            root_device="/dev/sda1",
+            description="Provided by Red Hat, Inc.",
+            sriov_net_support="simple",
+            ena_support=True,
+            billing_codes=AmiBillingCodes(name="Hourly2", codes=["bp-fake"]),
+            image_id="ami-fake-123456",
+        ),
+        AmiPushItem(
+            name="RHEL-SAP-8.4.0_HVM-20230109-x86_64-0-Hourly2-GP2",
+            state="PENDING",
+            src="/fake/path/aws/us-east-1-hourly/AWS_IMAGES/rhel-sap-ec2-8.4-20220802.sp.10.x86_64.raw",
+            dest=["us-east-1-hourly"],
+            md5sum=None,
+            sha256sum=None,
+            origin="/fake/path/aws/",
+            build=None,
+            build_info=None,
+            signing_key=None,
+            release=AmiRelease(
+                product="SAP",
+                date="20230109",
+                arch="x86_64",
+                respin=0,
+                version="8.4.0",
+                base_product="RHEL",
+                base_version=None,
+                variant="BaseOS",
+                type=None,
+            ),
+            type="hourly",
+            region="us-east-1",
+            virtualization="hvm",
+            volume="gp2",
+            root_device="/dev/sda1",
+            description="Provided by Red Hat, Inc.",
+            sriov_net_support="simple",
+            ena_support=True,
+            billing_codes=AmiBillingCodes(name="Hourly2", codes=["bp-fake"]),
+            image_id="ami-fake-200-A",
+        ),
+        AmiPushItem(
+            name="RHEL-SAP-8.4.0_HVM-20230109-x86_64-0-Hourly2-GP2",
+            state="PENDING",
+            src="/fake/path/aws/me-central-1-hourly/AWS_IMAGES/rhel-sap-ec2-8.4-20220802.sp.10.x86_64.raw",
+            dest=["me-central-1-hourly"],
+            md5sum=None,
+            sha256sum=None,
+            origin="/fake/path/aws/",
+            build=None,
+            build_info=None,
+            signing_key=None,
+            release=AmiRelease(
+                product="SAP",
+                date="20230109",
+                arch="x86_64",
+                respin=0,
+                version="8.4.0",
+                base_product="RHEL",
+                base_version=None,
+                variant="BaseOS",
+                type=None,
+            ),
+            type="hourly",
+            region="me-central-1",
+            virtualization="hvm",
+            volume="gp2",
+            root_device="/dev/sda1",
+            description="Provided by Red Hat, Inc.",
+            sriov_net_support="simple",
+            ena_support=True,
+            billing_codes=AmiBillingCodes(name="Hourly2", codes=["bp-fake"]),
+            image_id="ami-fake-200-B",
+        ),
+    ]
+
+
+def test_pub_source_invalid_task_id(requests_mock, caplog):
+    """
+    Tests behavior when invalid task id is passed to source.
+    """
+    # test setup
+    caplog.set_level(logging.WARNING)
+    task_id = "a7df9"
+    pub_url = "https://pub.example.com"
+    request_url = os.path.join(
+        pub_url, "pub/task", "123456", "log/images.json?format=raw"
+    )
+
+    requests_mock.register_uri("GET", request_url, json=make_response(123456))
+
+    # request push items from source
+    with Source.get("pub:%s" % pub_url, task_id=task_id) as source:
+        push_items = [item for item in source]
+
+    # no exception raise but also no push items
+    assert len(push_items) == 0
+    # with follow line captured in log
+    assert caplog.messages[0] == "Invalid Pub task ID: a7df9"
+
+
+def test_pub_source_empty_response(requests_mock, caplog):
+    """
+    Tests behavior when empty response is received from source.
+    """
+    # test setup
+    caplog.set_level(logging.WARNING)
+    task_id = 123456
+    pub_url = "https://pub.example.com"
+    request_url = os.path.join(
+        pub_url, "pub/task", "123456", "log/images.json?format=raw"
+    )
+
+    requests_mock.register_uri("GET", request_url, json={})
+
+    with Source.get("pub:%s" % pub_url, task_id=task_id) as source:
+        push_items = [item for item in source]
+
+    # there are no push items returned
+    assert len(push_items) == 0
+
+    # with details captured in logged
+    assert caplog.messages == ["Cannot parse AMI push item/s: {}"]
+
+
+def test_pub_source_missing_task(requests_mock, caplog):
+    """
+    Tests query for push items for non-existing Pub task.
+    """
+    # test setup
+    caplog.set_level(logging.WARNING)
+    task_id = 1234567890
+    pub_url = "https://pub.example.com"
+    request_url = os.path.join(
+        pub_url, "pub/task", "1234567890", "log/images.json?format=raw"
+    )
+
+    requests_mock.register_uri("GET", request_url, status_code=404)
+
+    # request push items - 404 received raises exception
+    with pytest.raises(requests.exceptions.HTTPError) as exc:
+        with Source.get("pub:%s" % pub_url, task_id=task_id) as source:
+            _ = [item for item in source]
+
+    assert "404 Client Error:" in str(exc.value)

--- a/tests/pub/test_pub_client.py
+++ b/tests/pub/test_pub_client.py
@@ -1,0 +1,202 @@
+import logging
+import os
+
+import pytest
+import requests
+
+from pushsource._impl.backend.pub_source import pub_client
+
+
+@pytest.fixture
+def test_client():
+    client = pub_client.PubClient(1, "https://test.example.com/")
+    yield client
+    client.shutdown()
+
+
+def test_pub_client_successful_request(requests_mock, caplog, test_client):
+    """
+    Test Pub client behavior for succesule response from service.
+    """
+    # test setup
+    caplog.set_level(logging.DEBUG)
+    task_id = 100
+    url = "https://test.example.com"
+    request_url = os.path.join(
+        url, "pub/task", str(task_id), "log/images.json?format=raw"
+    )
+    requests_mock.register_uri("GET", request_url, json={"test": "OK"})
+
+    # do request to service
+    client = test_client
+    json_ft = client.get_ami_json_f(100)
+
+    # we should get proper json response
+    assert json_ft.result() == {"test": "OK"}
+    # following lines are captured in logs
+    assert caplog.messages == [
+        "Requesting Pub service for log/images.json of task: 100",
+        "Creating requests Session for client of Pub service: https://test.example.com/",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 200",
+    ]
+
+
+def test_pub_client_corrupted_json(requests_mock, caplog, test_client):
+    """
+    Test Pub client behavior when no json or corrupted json is returned from service.
+    """
+    # test setup
+    caplog.set_level(logging.DEBUG)
+    task_id = 100
+    url = "https://test.example.com"
+    request_url = os.path.join(
+        url, "pub/task", str(task_id), "log/images.json?format=raw"
+    )
+    requests_mock.register_uri("GET", request_url, text="vcccccc")
+
+    # do request to service
+    client = test_client
+    json_ft = client.get_ami_json_f(100)
+
+    # we get None as response because of no valid json content
+    assert json_ft.result() == None
+    # following lines are captured in logs
+    assert caplog.messages == [
+        "Requesting Pub service for log/images.json of task: 100",
+        "Creating requests Session for client of Pub service: https://test.example.com/",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 200",
+    ]
+
+
+def test_pub_client_404_status(requests_mock, caplog, test_client):
+    """
+    Test Pub client behavior for 404 status code returned from service.
+    """
+    # test setup
+    caplog.set_level(logging.DEBUG)
+    task_id = 100
+    url = "https://test.example.com"
+    request_url = os.path.join(
+        url, "pub/task", str(task_id), "log/images.json?format=raw"
+    )
+    requests_mock.register_uri("GET", request_url, text="Not Found", status_code=404)
+
+    # do request to service - 404 raises exception
+    with pytest.raises(requests.exceptions.HTTPError) as exc:
+        client = test_client
+        json_ft = client.get_ami_json_f(100)
+        json_ft.result()
+
+    # following lines are captured in logs - more line due to retries
+    assert caplog.messages == [
+        "Requesting Pub service for log/images.json of task: 100",
+        "Creating requests Session for client of Pub service: https://test.example.com/",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 404",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 404",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 404",
+    ]
+    # check exception value
+    assert (
+        "404 Client Error: None for url: https://test.example.com/pub/task/100/log/images.json?format=raw"
+        in str(exc.value)
+    )
+
+
+def test_pub_client_500_status(requests_mock, caplog, test_client):
+    """
+    Test Pub client behavior for 500 status code returned from service.
+    """
+    # test setup
+    caplog.set_level(logging.DEBUG)
+    task_id = 100
+    url = "https://test.example.com"
+    request_url = os.path.join(
+        url, "pub/task", str(task_id), "log/images.json?format=raw"
+    )
+    requests_mock.register_uri(
+        "GET", request_url, text="Internal server error", status_code=500
+    )
+
+    # do request to service - 505 raises exception
+    with pytest.raises(requests.exceptions.HTTPError) as exc:
+        client = test_client
+        json_ft = client.get_ami_json_f(100)
+        json_ft.result()
+
+    # following lines are captured in logs - more line due to retries
+    assert caplog.messages == [
+        "Requesting Pub service for log/images.json of task: 100",
+        "Creating requests Session for client of Pub service: https://test.example.com/",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 500",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 500",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 500",
+    ]
+
+    # check exception value
+    assert (
+        "500 Server Error: None for url: https://test.example.com/pub/task/100/log/images.json?format=raw"
+        in str(exc.value)
+    )
+
+
+def test_pub_client_500_status(requests_mock, caplog, test_client):
+    """
+    Test Pub client behavior for 500 status code returned from service.
+    """
+    # test setup
+    caplog.set_level(logging.DEBUG)
+    task_id = 100
+    url = "https://test.example.com"
+    request_url = os.path.join(
+        url, "pub/task", str(task_id), "log/images.json?format=raw"
+    )
+    requests_mock.register_uri(
+        "GET", request_url, text="Internal server error", status_code=500
+    )
+
+    # do request to service - 505 raises exception
+    with pytest.raises(requests.exceptions.HTTPError) as exc:
+        client = test_client
+        json_ft = client.get_ami_json_f(100)
+        json_ft.result()
+
+    # following lines are captured in logs - more line due to retries
+    assert caplog.messages == [
+        "Requesting Pub service for log/images.json of task: 100",
+        "Creating requests Session for client of Pub service: https://test.example.com/",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 500",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 500",
+        "GET https://test.example.com/pub/task/100/log/images.json?format=raw 500",
+    ]
+
+    # check exception value
+    assert (
+        "500 Server Error: None for url: https://test.example.com/pub/task/100/log/images.json?format=raw"
+        in str(exc.value)
+    )
+
+
+def test_pub_client_timeout_error(requests_mock, caplog, test_client):
+    """
+    Test Pub client behavior for timeout exception while sending request.
+    """
+    # test setup
+    caplog.set_level(logging.DEBUG)
+    task_id = 100
+    url = "https://test.example.com"
+    request_url = os.path.join(
+        url, "pub/task", str(task_id), "log/images.json?format=raw"
+    )
+    requests_mock.register_uri("GET", request_url, exc=requests.exceptions.Timeout)
+
+    # do request to service - Timeout exception
+    with pytest.raises(requests.exceptions.Timeout):
+        client = test_client
+        json_ft = client.get_ami_json_f(100)
+        json_ft.result()
+
+    # following lines are captured in log.
+    assert caplog.messages == [
+        "Requesting Pub service for log/images.json of task: 100",
+        "Creating requests Session for client of Pub service: https://test.example.com/",
+    ]


### PR DESCRIPTION
Introduced new pushsource backend - `pub` for extracting push items
from Pub push item list by task id.

Pub backend currently supports extraction of AMI push items only. They
are extracted from images.json file stored on Pub service for each (AMI) task.

Little addition to AmiPushItem model class - added `image_id` attribute
that is unique identifier of AMI in AWS that is only knonw, if the AMI was
pushed previously to AWS.
