### PR TITLE
Fix bad validator on VHDPushItem.legacy_sku_id

### DIFF
--- a/src/pushsource/_impl/model/azure.py
+++ b/src/pushsource/_impl/model/azure.py
@@ -35,9 +35,7 @@ class VHDPushItem(VMIPushItem):
     support_legacy = attr.ib(type=bool, default=False, validator=instance_of(bool))
     """If the image ``generation == V2`` but also supports ``V1``."""
 
-    legacy_sku_id = attr.ib(
-        type=str, default=None, validator=optional(in_(VHDGeneration))
-    )
+    legacy_sku_id = attr.ib(type=str, default=None)
     """The ``V1`` SKU ID (only if ``support_legacy`` is true)."""
 
     disk_version = attr.ib(type=str, default=None)
@@ -59,4 +57,11 @@ class VHDPushItem(VMIPushItem):
         if value and not re.match(r"^(\d+\.)(\d+\.)(\*|\d+)$", value):
             raise ValueError(
                 r"Invalid disk version. Expected format: {int}.{int}.{int}"
+            )
+
+    def __attrs_post_init__(self):
+        if self.legacy_sku_id and not self.support_legacy:
+            raise ValueError(
+                'The attribute "legacy_sku_id" must only be set when'
+                ' "support_legacy" is True.'
             )

--- a/tests/model/test_vhd.py
+++ b/tests/model/test_vhd.py
@@ -20,6 +20,22 @@ def test_invalid_disk_version():
     )
 
 
+def test_invalid_legacy_sku():
+    """Can't create VHDPushItem with legacy_sku set when legacy_support is False."""
+    with raises(ValueError) as exc_info:
+        VHDPushItem(
+            name="test",
+            description="test",
+            disk_version="1.0.0",
+            sas_uri="foo.com/bar",
+            support_legacy=False,
+            legacy_sku_id="legacy_sku_id",
+        )
+    assert (
+        'The attribute "legacy_sku_id" must only be set when "support_legacy" is True.'
+    ) in str(exc_info.value)
+
+
 def test_vmi_release():
     """Ensure that subclasses of VMIRelease can not be associated with VHDPushItem."""
     release_params = {


### PR DESCRIPTION
This PR fixes a bad behaviro on `VHDPushItem.legacy_sku_id' which should only be set whenever `support_legacy` is True.

If the constraint is respected the value of `legacy_sku_id` can be any string, however the previous version was limiting it in `V1` or `V2` (same as `generation`) which shouldn't be the case.