### PR TITLE
Don't log during stagedir wait if wait is disabled

### DIFF
--- a/src/pushsource/_impl/backend/staged/staged_source.py
+++ b/src/pushsource/_impl/backend/staged/staged_source.py
@@ -164,7 +164,7 @@ class StagedSource(
                 wait_time,
             )
             time.sleep(wait_time)
-        else:
+        elif apply_wait_topdir_age:
             LOG.info(
                 "Directory '%s' has mtime %s+00:00, being more than "
                 "%s seconds old. Skipping the wait.",

--- a/tests/staged/test_staged_simple_rpm.py
+++ b/tests/staged/test_staged_simple_rpm.py
@@ -193,7 +193,4 @@ def test_staged_simple_rpm_age_check_disabled(
     mock_load_metadata.assert_called_once()
     mock_push_items_for_leafdir.assert_called()
 
-    assert (
-        "has mtime 1970-01-01T00:16:40+00:00, being more than 0 seconds old. "
-        "Skipping the wait." in caplog.records[1].message
-    )
+    assert "Skipping the wait" not in caplog.text


### PR DESCRIPTION
The addition of this log caused some log-based tests in other projects to start failing due to new log messages appearing like this:

      [    INFO] Directory '/tmp/aws_staged' has mtime 2023-02-05T20:28:28+00:00,
      being more than 0 seconds old. Skipping the wait.

I don't think the log message makes sense anyway if the waiting feature has been disabled by setting the threshold to 0 seconds, so let's not log in that case.