### PR TITLE
Fixed frozendict convertor to core.frozendict

### DIFF
--- a/src/pushsource/_impl/model/container.py
+++ b/src/pushsource/_impl/model/container.py
@@ -1,10 +1,10 @@
 import re
 
 from frozenlist2 import frozenlist
+from frozendict.core import frozendict  # pylint: disable=no-name-in-module
 
 from .base import PushItem
 from .. import compat_attr as attr
-from frozendict import frozendict
 from .conv import instance_of, optional_str
 
 

--- a/src/pushsource/_impl/model/conv.py
+++ b/src/pushsource/_impl/model/conv.py
@@ -5,7 +5,7 @@ from functools import partial
 import re
 
 from frozenlist2 import frozenlist
-from frozendict.core import frozendict
+from frozendict.core import frozendict # pylint: disable=no-name-in-module
 from dateutil import tz
 
 from .. import compat_attr as attr
@@ -197,7 +197,7 @@ def unfreeze(obj):
     for titem in traversal:
         cobj, cparent, ckey = titem
         cparent[ckey] = cobj
-
+    
     return ret[0]
 
 

--- a/src/pushsource/_impl/model/conv.py
+++ b/src/pushsource/_impl/model/conv.py
@@ -5,7 +5,7 @@ from functools import partial
 import re
 
 from frozenlist2 import frozenlist
-from frozendict import frozendict
+from frozendict.core import frozendict
 from dateutil import tz
 
 from .. import compat_attr as attr

--- a/src/pushsource/_impl/model/conv.py
+++ b/src/pushsource/_impl/model/conv.py
@@ -5,7 +5,7 @@ from functools import partial
 import re
 
 from frozenlist2 import frozenlist
-from frozendict.core import frozendict # pylint: disable=no-name-in-module
+from frozendict.core import frozendict  # pylint: disable=no-name-in-module
 from dateutil import tz
 
 from .. import compat_attr as attr
@@ -197,7 +197,7 @@ def unfreeze(obj):
     for titem in traversal:
         cobj, cparent, ckey = titem
         cparent[ckey] = cobj
-    
+
     return ret[0]
 
 


### PR DESCRIPTION
validation of container_list in erratum model is set to check if instance of frozen dict is frozendict.core.frozendict which is not "compatible" with frozendict.frozendict