### PR TITLE
Add public_image flag for AMI images [RHELDST-16452]

### DIFF
--- a/src/pushsource/_impl/backend/staged/staged_ami.py
+++ b/src/pushsource/_impl/backend/staged/staged_ami.py
@@ -56,6 +56,7 @@ class StagedAmiMixin(StagedBaseMixin):
             "description",
             "sriov_net_support",
             "ena_support",
+            "public_image",
         ]
 
         for key in image_attrs:

--- a/src/pushsource/_impl/model/ami.py
+++ b/src/pushsource/_impl/model/ami.py
@@ -102,6 +102,11 @@ class AmiPushItem(VMIPushItem):
     image_id = attr.ib(type=str, default=None, validator=optional_str)
     """AMI Image ID used to reference the image in AWS."""
 
+    public_image = attr.ib(
+        type=bool, default=None, validator=optional(instance_of(bool))
+    )
+    """``True`` if the image is allowed to be released publicly (shared with group "all")."""
+
     @classmethod
     def _from_data(cls, data):
         """Instantiate AmiPushItem from raw list or dict"""
@@ -125,11 +130,12 @@ class AmiPushItem(VMIPushItem):
             "root_device": data["root_device"],
             "description": data["description"],
             "sriov_net_support": data["sriov_net_support"],
-            "ena_support": data.get("ena_support") or None,
+            "ena_support": data.get("ena_support"),
             "billing_codes": AmiBillingCodes._from_data(
                 data.get("billing_codes") or {}
             ),
             "image_id": data.get("ami") or None,
+            "public_image": data.get("public_image"),
         }
 
         return cls(**kwargs)

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -100,6 +100,10 @@ definitions:
             billing_codes:
                 $ref: "#/definitions/ami_billing_codes"
 
+            public_image:
+                type:
+                - boolean
+                - "null"
 
         required:
         - release

--- a/tests/baseline/cases/staged-simple-ami-bc.yml
+++ b/tests/baseline/cases/staged-simple-ami-bc.yml
@@ -24,6 +24,7 @@ items:
     md5sum: null
     name: fake-image.raw
     origin: {{ src_dir }}/tests/staged/data/simple_ami_with_bc
+    public_image: true
     region: cn-north-1
     release:
       arch: x86_64

--- a/tests/baseline/cases/staged-simple-ami.yml
+++ b/tests/baseline/cases/staged-simple-ami.yml
@@ -20,6 +20,7 @@ items:
     md5sum: null
     name: fake-image.raw
     origin: {{ src_dir }}/tests/staged/data/simple_ami
+    public_image: true
     region: cn-north-1
     release:
       arch: x86_64

--- a/tests/staged/data/simple_ami/staged.yaml
+++ b/tests/staged/data/simple_ami/staged.yaml
@@ -23,3 +23,4 @@ payload:
       type: access
       virtualization: hvm
       volume: gp2
+      public_image: true

--- a/tests/staged/data/simple_ami_with_bc/staged.yaml
+++ b/tests/staged/data/simple_ami_with_bc/staged.yaml
@@ -28,4 +28,4 @@ payload:
         codes:
           - bp-1234
           - bp-abcd
-
+      public_image: true


### PR DESCRIPTION
The `public_image` flag designates whether the AMI image is allowed to be released publicly (shared with group "all") as some images are expected to be "shipped live" by going through all the standard steps with the exception of being shared publicly.

This commit also fixes logic for getting the `ena_support` flag. Previously, when the flag was set to `False`, the
`AmiPushItem._from_data()` method unintentionally converted it to `None`. Now it remains set to `False`.

This PR relates to https://github.com/release-engineering/pubtools-ami/pull/93