### PR TITLE
Fix tox on development environment

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,3 +7,4 @@ frozendict; python_version >= '3.6'
 frozenlist2
 python-dateutil
 kobo
+pytz; python_version < '3.9'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,static,docs
+envlist = py39,static,docs
 
 [testenv]
 deps=


### PR DESCRIPTION
This commit fix the `tox` command on local environment by allowing the tests on `Python 3.8` to pass.

Before this commit the tests were failing on `Python 3.8` as the dependency `pytz` couldn't be installed on require-hashes mode.

This commit applies the following changes:

- Add `pytz` as a dependency for `Python < 3.9`
- Change the `pip-compile` command to run on `Python 3.8` by default
- Rebuild all requirements files using `tox`