### PR TITLE
Allow to run tox localy with older version of python

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,18 @@ usedevelop=true
 commands=
 	pytest --cov-report=html --cov-report=xml --cov=src --cov-fail-under=100 {posargs}
 
+[testenv:py38]
+deps=
+    -rtest-requirements.in
+
+[testenv:py37]
+deps=
+    -rtest-requirements.in
+
+[testenv:py36]
+deps=
+    -rtest-requirements.in
+
 [testenv:docs]
 use_develop=true
 commands=


### PR DESCRIPTION
The project support python3.6+
```
  sh$ grep python_requires setup.py
    python_requires=">=3.6",
  sh$ git log -1 --oneline origin/master
  b0cd3e6 (origin/master, origin/HEAD, master) Merge pull request #321 from JAVGan/fixtests
```

But it failed in tox, because pinned dependencies are for python3.9.
This is a workaround to allow testing locally with tox and older version with un-pinned dependencies

```
sh$ tox -e py37

// snip

ERROR: Could not find a version that satisfies the requirement isort==5.12.0 (from versions: 1.0.0, 1.0.1, 1.2.0, 1.2.2, 1.2.3, 1.2.5, 1.3.0, 1.3.1, 1.3.2, 2.0.0, 2.0.1, 2.1.0, 2.2.0, 2.2.1, 2.3.0, 2.4.0, 2.4.1, 2.5.0, 2.6.0, 2.6.1, 2.6.2, 2.6.3, 3.0.0, 3.1.0, 3.1.1, 3.1.2, 3.2.0, 3.3.0, 3.3.1, 3.4.0, 3.4.1, 3.4.2, 3.5.0, 3.6.0, 3.6.1, 3.6.2, 3.7.0, 3.7.1, 3.7.2, 3.8.0, 3.8.1, 3.8.2, 3.8.3, 3.9.0, 3.9.1, 3.9.2, 3.9.3, 3.9.4, 3.9.5, 3.9.6, 4.0.0, 4.1.0, 4.1.1, 4.1.2, 4.2.0, 4.2.1, 4.2.2, 4.2.3, 4.2.4, 4.2.5, 4.2.8, 4.2.9, 4.2.11, 4.2.12, 4.2.13, 4.2.14, 4.2.15, 4.3.0, 4.3.1, 4.3.2, 4.3.3, 4.3.4, 4.3.5, 4.3.6, 4.3.7, 4.3.8, 4.3.9, 4.3.10, 4.3.11, 4.3.12, 4.3.13, 4.3.14, 4.3.15, 4.3.16, 4.3.17, 4.3.18, 4.3.19, 4.3.20, 4.3.21, 5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.0.6, 5.0.7, 5.0.8, 5.0.9, 5.1.0, 5.1.1, 5.1.2, 5.1.3, 5.1.4, 5.2.0, 5.2.1, 5.2.2, 5.3.0, 5.3.1, 5.3.2, 5.4.0, 5.4.1, 5.4.2, 5.5.0, 5.5.1, 5.5.2, 5.5.3, 5.5.4, 5.5.5, 5.6.0, 5.6.1, 5.6.2, 5.6.3, 5.6.4, 5.7.0, 5.8.0, 5.9.0, 5.9.1, 5.9.2, 5.9.3, 5.10.0, 5.10.1, 5.11.0, 5.11.1, 5.11.2, 5.11.3, 5.11.4, 5.11.5, 6.0.0a1, 6.0.0b1, 6.0.0b2)
ERROR: No matching distribution found for isort==5.12.0
WARNING: You are using pip version 21.3.1; however, version 23.0.1 is available. You should consider upgrading via the '/home/user/projects/pushsource/.tox/py37/bin/python -m pip install --upgrade pip' command.

=========================== log end ========================================== ERROR: could not install deps [-rtest-requirements.txt]; v = InvocationError('/home/user/projects/pushsource/.tox/py37/bin/python -m pip install -rtest-requirements.txt', 1) ___________________________ summary __________________________________________
ERROR:   py37: could not install deps [-rtest-requirements.txt]; v = InvocationError('/home/user/projects/pushsource/.tox/py37/bin/python -m pip install -rtest-requirements.txt', 1)
```