### PR TITLE
Allow KojiSource to store the build id

### DIFF
--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -496,6 +496,7 @@ class KojiSource(Source):
                     # brew builds whose NVR does not match their (n, v, r)
                     # in the build data and it's quite tough to fix that now.
                     build_info=KojiBuildInfo(
+                        id=int(build_id),
                         name=meta["name"],
                         version=meta["version"],
                         release=meta["release"],
@@ -607,6 +608,7 @@ class KojiSource(Source):
                     src=item_src,
                     build=nvr,
                     build_info=KojiBuildInfo(
+                        id=int(build_id),
                         name=meta["name"],
                         version=meta["version"],
                         release=meta["release"],

--- a/src/pushsource/_impl/model/base.py
+++ b/src/pushsource/_impl/model/base.py
@@ -7,11 +7,13 @@ from frozenlist2 import frozenlist
 from .. import compat_attr as attr
 from .cache import TinyCache
 from .conv import (
+    convert_maybe,
     md5str,
     sha256str,
     upper_if_str,
     instance_of_str,
     instance_of,
+    optional,
     optional_str,
 )
 
@@ -41,6 +43,14 @@ class KojiBuildInfo(object):
 
     Example: in "kf5-kio-5.83.0-2.el8.next", the release is "2.el8.next".
     """
+
+    id = attr.ib(
+        type=int,
+        default=None,
+        validator=optional(instance_of(int)),
+        converter=convert_maybe(int),
+    )
+    """Optional attribute to store the 'build_id' from Koji."""
 
     @classmethod
     def _from_nvr(cls, nvr_str):

--- a/tests/baseline/cases/errata-containers-legacy-repos.yml
+++ b/tests/baseline/cases/errata-containers-legacy-repos.yml
@@ -12,6 +12,7 @@ items:
     arch: s390x
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248993
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -61,6 +62,7 @@ items:
     arch: arm64
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248993
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -110,6 +112,7 @@ items:
     arch: amd64
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248993
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -159,6 +162,7 @@ items:
     arch: ppc64le
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248993
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -208,6 +212,7 @@ items:
     arch: amd64
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248998
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -257,6 +262,7 @@ items:
     arch: ppc64le
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248998
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -306,6 +312,7 @@ items:
     arch: s390x
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248998
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -355,6 +362,7 @@ items:
     arch: arm64
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248998
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -404,6 +412,7 @@ items:
     arch: ppc64le
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248994
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -453,6 +462,7 @@ items:
     arch: arm64
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248994
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -502,6 +512,7 @@ items:
     arch: s390x
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248994
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -551,6 +562,7 @@ items:
     arch: amd64
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248994
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -600,6 +612,7 @@ items:
     arch: amd64
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248963
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -649,6 +662,7 @@ items:
     arch: arm64
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248963
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -698,6 +712,7 @@ items:
     arch: ppc64le
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248963
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -747,6 +762,7 @@ items:
     arch: s390x
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248963
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -796,6 +812,7 @@ items:
     arch: arm64
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1249006
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -846,6 +863,7 @@ items:
     arch: ppc64le
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1249006
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -896,6 +914,7 @@ items:
     arch: amd64
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1249006
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -946,6 +965,7 @@ items:
     arch: s390x
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1249006
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -996,6 +1016,7 @@ items:
     arch: amd64
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248997
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1045,6 +1066,7 @@ items:
     arch: arm64
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248997
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1094,6 +1116,7 @@ items:
     arch: ppc64le
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248997
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1143,6 +1166,7 @@ items:
     arch: s390x
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248997
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1192,6 +1216,7 @@ items:
     arch: arm64
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248981
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1241,6 +1266,7 @@ items:
     arch: s390x
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248981
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1290,6 +1316,7 @@ items:
     arch: amd64
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248981
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1339,6 +1366,7 @@ items:
     arch: ppc64le
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248981
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1388,6 +1416,7 @@ items:
     arch: s390x
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248956
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1437,6 +1466,7 @@ items:
     arch: ppc64le
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248956
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1486,6 +1516,7 @@ items:
     arch: amd64
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248956
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1535,6 +1566,7 @@ items:
     arch: arm64
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248956
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1584,6 +1616,7 @@ items:
     arch: amd64
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248969
       name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1633,6 +1666,7 @@ items:
     arch: ppc64le
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248969
       name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1682,6 +1716,7 @@ items:
     arch: s390x
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248969
       name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1731,6 +1766,7 @@ items:
     arch: arm64
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248969
       name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1878,6 +1914,7 @@ items:
 - OperatorManifestPushItem:
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1893,6 +1930,7 @@ items:
 - OperatorManifestPushItem:
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1908,6 +1946,7 @@ items:
 - OperatorManifestPushItem:
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1923,6 +1962,7 @@ items:
 - OperatorManifestPushItem:
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1938,6 +1978,7 @@ items:
 - OperatorManifestPushItem:
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1953,6 +1994,7 @@ items:
 - OperatorManifestPushItem:
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1968,6 +2010,7 @@ items:
 - OperatorManifestPushItem:
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1983,6 +2026,7 @@ items:
 - OperatorManifestPushItem:
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod

--- a/tests/baseline/cases/errata-containers.yml
+++ b/tests/baseline/cases/errata-containers.yml
@@ -12,6 +12,7 @@ items:
     arch: s390x
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248993
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -61,6 +62,7 @@ items:
     arch: arm64
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248993
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -110,6 +112,7 @@ items:
     arch: amd64
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248993
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -159,6 +162,7 @@ items:
     arch: ppc64le
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248993
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -208,6 +212,7 @@ items:
     arch: amd64
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248998
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -257,6 +262,7 @@ items:
     arch: ppc64le
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248998
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -306,6 +312,7 @@ items:
     arch: s390x
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248998
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -355,6 +362,7 @@ items:
     arch: arm64
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248998
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -404,6 +412,7 @@ items:
     arch: ppc64le
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248994
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -453,6 +462,7 @@ items:
     arch: arm64
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248994
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -502,6 +512,7 @@ items:
     arch: s390x
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248994
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -551,6 +562,7 @@ items:
     arch: amd64
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248994
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -600,6 +612,7 @@ items:
     arch: amd64
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248963
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -649,6 +662,7 @@ items:
     arch: arm64
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248963
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -698,6 +712,7 @@ items:
     arch: ppc64le
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248963
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -747,6 +762,7 @@ items:
     arch: s390x
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248963
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -796,6 +812,7 @@ items:
     arch: arm64
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1249006
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -846,6 +863,7 @@ items:
     arch: ppc64le
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1249006
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -896,6 +914,7 @@ items:
     arch: amd64
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1249006
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -946,6 +965,7 @@ items:
     arch: s390x
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1249006
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -996,6 +1016,7 @@ items:
     arch: amd64
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248997
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1045,6 +1066,7 @@ items:
     arch: arm64
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248997
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1094,6 +1116,7 @@ items:
     arch: ppc64le
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248997
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1143,6 +1166,7 @@ items:
     arch: s390x
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248997
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1192,6 +1216,7 @@ items:
     arch: arm64
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248981
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1241,6 +1266,7 @@ items:
     arch: s390x
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248981
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1290,6 +1316,7 @@ items:
     arch: amd64
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248981
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1339,6 +1366,7 @@ items:
     arch: ppc64le
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248981
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1388,6 +1416,7 @@ items:
     arch: s390x
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248956
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1437,6 +1466,7 @@ items:
     arch: ppc64le
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248956
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1486,6 +1516,7 @@ items:
     arch: amd64
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248956
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1535,6 +1566,7 @@ items:
     arch: arm64
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248956
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1584,6 +1616,7 @@ items:
     arch: amd64
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248969
       name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1633,6 +1666,7 @@ items:
     arch: ppc64le
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248969
       name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1682,6 +1716,7 @@ items:
     arch: s390x
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248969
       name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1731,6 +1766,7 @@ items:
     arch: arm64
     build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: 1248969
       name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1878,6 +1914,7 @@ items:
 - OperatorManifestPushItem:
     build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: cluster-logging-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1893,6 +1930,7 @@ items:
 - OperatorManifestPushItem:
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: cluster-nfd-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1908,6 +1946,7 @@ items:
 - OperatorManifestPushItem:
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: elasticsearch-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1923,6 +1962,7 @@ items:
 - OperatorManifestPushItem:
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: local-storage-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1938,6 +1978,7 @@ items:
 - OperatorManifestPushItem:
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: openshift-enterprise-ansible-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1953,6 +1994,7 @@ items:
 - OperatorManifestPushItem:
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: openshift-enterprise-template-service-broker-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1968,6 +2010,7 @@ items:
 - OperatorManifestPushItem:
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: ose-metering-ansible-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
@@ -1983,6 +2026,7 @@ items:
 - OperatorManifestPushItem:
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
+      id: null
       name: ose-ptp-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod

--- a/tests/baseline/cases/koji-operator-container.yml
+++ b/tests/baseline/cases/koji-operator-container.yml
@@ -12,6 +12,7 @@ items:
     arch: amd64
     build: security-profiles-operator-bundle-container-0.5.2-2
     build_info:
+      id: 2398004
       name: security-profiles-operator-bundle-container
       release: '2'
       version: 0.5.2
@@ -58,6 +59,7 @@ items:
 - OperatorManifestPushItem:
     build: security-profiles-operator-bundle-container-0.5.2-2
     build_info:
+      id: null
       name: security-profiles-operator-bundle-container
       release: '2'
       version: 0.5.2

--- a/tests/baseline/cases/koji-source-container.yml
+++ b/tests/baseline/cases/koji-source-container.yml
@@ -12,6 +12,7 @@ items:
     arch: amd64
     build: openstack-swift-container-container-source-16.1.6-6.1
     build_info:
+      id: 1640546
       name: openstack-swift-container-container-source
       release: '6.1'
       version: 16.1.6

--- a/tests/errata/test_errata_vmis.py
+++ b/tests/errata/test_errata_vmis.py
@@ -87,6 +87,7 @@ def test_errata_ami_via_koji(fake_errata_tool, fake_koji, koji_dir):
                 name="rhel",
                 version="8.7",
                 release="1",
+                id="1234",
             ),
             signing_key=None,
             release=AmiRelease(
@@ -195,6 +196,7 @@ def test_errata_vhd_via_koji(fake_errata_tool, fake_koji, koji_dir):
                 name="rhel",
                 version="8.7",
                 release="1",
+                id="1234",
             ),
             signing_key=None,
             release=VMIRelease(

--- a/tests/koji/test_koji_vmi.py
+++ b/tests/koji/test_koji_vmi.py
@@ -9,6 +9,7 @@ from pushsource import (
     VMIPushItem,
     AmiRelease,
     VMIRelease,
+    KojiBuildInfo,
 )
 
 
@@ -160,6 +161,9 @@ def test_koji_vmis(fake_koji, koji_dir):
             sha256sum=None,
             origin=None,
             build=nvr,
+            build_info=KojiBuildInfo(
+                name=name, version=version, release=release, id=1234
+            ),
             signing_key=None,
             release=rel_obj,
         )
@@ -223,6 +227,9 @@ def test_koji_vmi_compound_product_name(fake_koji, koji_dir):
         sha256sum=None,
         origin=None,
         build="foobuild-azure-1.0-1",
+        build_info=KojiBuildInfo(
+            name="foobuild-azure", version="1.0", release="1", id=1234
+        ),
         signing_key=None,
         release=rel_obj,
     )


### PR DESCRIPTION
This PR changes the `KojiSource` to store the build id for containers and VMIs whenever it's available.
    
It adds an optional attribute `id` into the `KojiBuildInfo` model to  support the change and update the related tests.
    
Refers to EXDSP-2099
