### PR TITLE
Remove setting src in container push items

### DIFF
--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -472,7 +472,6 @@ class KojiSource(Source):
         out = []
 
         for archive in image_archives:
-
             helper = ContainerArchiveHelper(meta, archive)
 
             klass = ContainerImagePushItem

--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -472,8 +472,6 @@ class KojiSource(Source):
         out = []
 
         for archive in image_archives:
-            path = self._pathinfo.typedir(meta, archive["btype"])
-            item_src = os.path.join(path, archive["filename"])
 
             helper = ContainerArchiveHelper(meta, archive)
 
@@ -488,7 +486,6 @@ class KojiSource(Source):
                     # the metadata from atomic-reactor.
                     name=archive["filename"],
                     dest=self._dest,
-                    src=item_src,
                     build=nvr,
                     # Note, we should be able to use the default KojiBuild
                     # construction from NVR here. The reason we don't is that
@@ -647,14 +644,9 @@ class KojiSource(Source):
             ) % (nvr, archive_name)
             raise ValueError(message)
 
-        archive = operator_archive[0]
-        path = self._pathinfo.typedir(meta, archive["btype"])
-        item_src = os.path.join(path, archive["filename"])
-
         return OperatorManifestPushItem(
             name=os.path.join(nvr, archive_name),
             dest=self._dest,
-            src=item_src,
             build=nvr,
             related_images=operator_related_images,
         )

--- a/tests/baseline/cases/errata-containers-legacy-repos.yml
+++ b/tests/baseline/cases/errata-containers-legacy-repos.yml
@@ -9,136 +9,36 @@ url: "erratatest:errata=RHBA-2020:2807&legacy_container_repos=yes"
 # Push items generated from above.
 items:
 - ContainerImagePushItem:
-    arch: s390x
-    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248993
-      name: cluster-logging-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-03.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: cluster-logging-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      - digest: sha256:5748c3cfdc9c493f1538d55137a84c25560e4344f097314d9e12b838c0bba189
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248993
-      name: cluster-logging-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: cluster-logging-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      - digest: sha256:759da12e95ff57da1e0c83ee534f78a2292b79c1bf288e40ff1cb256d42440a7
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
     arch: amd64
-    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
-      id: 1248993
-      name: cluster-logging-operator-metadata-container
+      id: 1248969
+      name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
     dest:
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
     labels:
-      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
       com.redhat.delivery.appregistry: 'true'
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
-    name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
+    name: docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
     origin: RHBA-2020:2807
     pull_info:
       digest_specs:
-      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
         media_type: application/vnd.docker.distribution.manifest.list.v2+json
         registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      - digest: sha256:f5453808b4231f2b1e3121c8d302ed755475a76154ae353b49381966830c9a18
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      - digest: sha256:1bf775f662528cbbbab881b78eabbff551c27f5c678429ec87feff3cc84bd87d
         media_type: application/vnd.docker.distribution.manifest.v2+json
         registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
       media_types:
       - application/vnd.docker.distribution.manifest.list.v2+json
       - application/vnd.docker.distribution.manifest.v2+json
@@ -146,267 +46,17 @@ items:
       - media_types:
         - application/vnd.docker.distribution.manifest.list.v2+json
         registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
       - media_types: []
         registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
     sha256sum: null
     signing_key: null
     source_tags:
-    - rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248993
-      name: cluster-logging-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-06.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: cluster-logging-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      - digest: sha256:a279d2c29442bfa73550c428c30b058632e0656502ace41f7fffb8c44ed5b9fe
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248998
-      name: cluster-nfd-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: cluster-nfd-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      - digest: sha256:64e2392a10efacb98ab79db839babe4031f6ff94f832c7ab5ca52d1d6e124ea6
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248998
-      name: cluster-nfd-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: cluster-nfd-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      - digest: sha256:76c416c5dd128cb95f84c5ae277dd954bee390b2ad2e77d295aa01af5cf3b203
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248998
-      name: cluster-nfd-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: cluster-nfd-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      - digest: sha256:7d24896df49bf8969d9e92b177ca44dce42dc8878f4a8bb4073e1a245e6e8b24
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248998
-      name: cluster-nfd-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: cluster-nfd-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      - digest: sha256:edf7feb928d85e0b8d2c64bdcd893c9a149f6767beb10579a051714b9e7c2503
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
+    - rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: ppc64le
@@ -456,7 +106,157 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-80524-20200707075228-ppc64le
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248969
+      name: sriov-network-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      - digest: sha256:00a74f6340dc8defd262b67e02c596e6ec7ad40238943fd5cc2bb911caf1a0de
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248981
+      name: ose-metering-ansible-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      - digest: sha256:ba151c6f9fa29414b5aa0163fe4a2176c6eb6b9bbc32a98d27ece6fbb9fa00c0
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248981
+      name: ose-metering-ansible-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      - digest: sha256:92727964274c003c4e27f6f55ab3ebae2f96c7225511ece3061714f82368aa09
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: arm64
@@ -506,307 +306,7 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-50417-20200707075226-aarch64
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248994
-      name: elasticsearch-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-02.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: elasticsearch-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:a595bff056e37d4d61cc9225504bf7f969adcdd53f8f5180176b612c17ceaedc
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-      - digest: sha256:d6d01ef696e32c0a6a177c6098550e3583208841462489669006700e33da1fe7
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-57368-20200707075038
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248994
-      name: elasticsearch-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: elasticsearch-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:a595bff056e37d4d61cc9225504bf7f969adcdd53f8f5180176b612c17ceaedc
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-      - digest: sha256:f205a649e55b8757792a4d96ca5cfdadf6d717a11916fb47abb6fae623ff9e10
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-57368-20200707075038
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248963
-      name: local-storage-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: local-storage-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      - digest: sha256:482031ade5610ae584e5c75f844ad8139b4b18a6b7525a29517f5e4cbaf1646b
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248963
-      name: local-storage-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: local-storage-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      - digest: sha256:30f197a9de12601460d006e1f8b33e66fe355a46de75cf11c959df8bfc9bdaaa
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248963
-      name: local-storage-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c2-vm-03.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: local-storage-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      - digest: sha256:4e3e4ece862f9bb5ff473efb637c47ebb4916d5925270495583f86d19d22bbf8
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248963
-      name: local-storage-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c2-vm-03.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: local-storage-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      - digest: sha256:53fb41caedbff04e8ed8b7fab5ec761214c0578303080820223d54282ea95f5a
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: arm64
@@ -857,7 +357,457 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-46533-20200707080442-aarch64
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248956
+      name: ose-ptp-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-ptp-operator-metadata:v4.3
+    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      - digest: sha256:f644b80c1a21401eb1fa79b6e2732db05818562850c6d9acb41413d4b1524847
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248993
+      name: cluster-logging-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      - digest: sha256:5748c3cfdc9c493f1538d55137a84c25560e4344f097314d9e12b838c0bba189
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248994
+      name: elasticsearch-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-02.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:a595bff056e37d4d61cc9225504bf7f969adcdd53f8f5180176b612c17ceaedc
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+      - digest: sha256:d6d01ef696e32c0a6a177c6098550e3583208841462489669006700e33da1fe7
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-57368-20200707075038
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248997
+      name: openshift-enterprise-template-service-broker-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      - digest: sha256:ea0ee5a340f99259c725dec0c2bafd10f569ffb8223db5c73d3f52e7df446058
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248963
+      name: local-storage-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      - digest: sha256:482031ade5610ae584e5c75f844ad8139b4b18a6b7525a29517f5e4cbaf1646b
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248994
+      name: elasticsearch-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:a595bff056e37d4d61cc9225504bf7f969adcdd53f8f5180176b612c17ceaedc
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+      - digest: sha256:f205a649e55b8757792a4d96ca5cfdadf6d717a11916fb47abb6fae623ff9e10
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-57368-20200707075038
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248997
+      name: openshift-enterprise-template-service-broker-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      - digest: sha256:332c4e13f2d0329d03fea2702b71070c2d4bbfe1f6753e6a963d0aa41a08086e
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248997
+      name: openshift-enterprise-template-service-broker-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-04.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      - digest: sha256:6d76d7291e57bf0236bd14ef6a786d4b5140553443172595a6a60a6b6b340a7e
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248956
+      name: ose-ptp-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-ptp-operator-metadata:v4.3
+    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c2-vm-02.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      - digest: sha256:d063d90f70fbfd210175023f564b1cfccebf52cda6fab7f9ab606e08a4095771
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: ppc64le
@@ -908,7 +858,557 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-13114-20200707080444-ppc64le
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248981
+      name: ose-metering-ansible-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      - digest: sha256:6818dad3b9da5bbc6b728f6f5590467fd34c37f3a1a5e2c9f3aabeef84fed12f
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248969
+      name: sriov-network-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      - digest: sha256:b114fc0ff28650327a061d944ccc0ed4c20d16f32a826d8748b32439807e714f
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248998
+      name: cluster-nfd-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      - digest: sha256:64e2392a10efacb98ab79db839babe4031f6ff94f832c7ab5ca52d1d6e124ea6
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248969
+      name: sriov-network-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      - digest: sha256:ab5ea2465f9d924c9f0e30a74ab57990dab383271c19dde33f35ec397be0386c
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248963
+      name: local-storage-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      - digest: sha256:30f197a9de12601460d006e1f8b33e66fe355a46de75cf11c959df8bfc9bdaaa
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248956
+      name: ose-ptp-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-ptp-operator-metadata:v4.3
+    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1008.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      - digest: sha256:a5d2edb02c21c769ed90593520511f954d9de63680e338bc457fc2289b9725a3
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248998
+      name: cluster-nfd-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      - digest: sha256:76c416c5dd128cb95f84c5ae277dd954bee390b2ad2e77d295aa01af5cf3b203
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248993
+      name: cluster-logging-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      - digest: sha256:759da12e95ff57da1e0c83ee534f78a2292b79c1bf288e40ff1cb256d42440a7
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248998
+      name: cluster-nfd-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      - digest: sha256:7d24896df49bf8969d9e92b177ca44dce42dc8878f4a8bb4073e1a245e6e8b24
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248993
+      name: cluster-logging-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      - digest: sha256:f5453808b4231f2b1e3121c8d302ed755475a76154ae353b49381966830c9a18
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248981
+      name: ose-metering-ansible-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      - digest: sha256:e010ea8e6a50e917a7884d971aafc06d783ae69fe7c40a372e7bc7acf7cf273b
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: amd64
@@ -959,7 +1459,257 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-12704-20200707080441-x86_64
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248993
+      name: cluster-logging-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-06.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      - digest: sha256:a279d2c29442bfa73550c428c30b058632e0656502ace41f7fffb8c44ed5b9fe
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248963
+      name: local-storage-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c2-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      - digest: sha256:4e3e4ece862f9bb5ff473efb637c47ebb4916d5925270495583f86d19d22bbf8
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248963
+      name: local-storage-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      - digest: sha256:53fb41caedbff04e8ed8b7fab5ec761214c0578303080820223d54282ea95f5a
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248997
+      name: openshift-enterprise-template-service-broker-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      - digest: sha256:f65555acb07c7e0c590389f55a16a395b9c7eb8071de2f0f32a273ea4d36fa03
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248998
+      name: cluster-nfd-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - redhat-openshift4-ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      - digest: sha256:edf7feb928d85e0b8d2c64bdcd893c9a149f6767beb10579a051714b9e7c2503
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: s390x
@@ -1010,557 +1760,7 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-48676-20200707080442-s390x
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248997
-      name: openshift-enterprise-template-service-broker-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      - digest: sha256:ea0ee5a340f99259c725dec0c2bafd10f569ffb8223db5c73d3f52e7df446058
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248997
-      name: openshift-enterprise-template-service-broker-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      - digest: sha256:332c4e13f2d0329d03fea2702b71070c2d4bbfe1f6753e6a963d0aa41a08086e
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248997
-      name: openshift-enterprise-template-service-broker-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-04.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      - digest: sha256:6d76d7291e57bf0236bd14ef6a786d4b5140553443172595a6a60a6b6b340a7e
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248997
-      name: openshift-enterprise-template-service-broker-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      - digest: sha256:f65555acb07c7e0c590389f55a16a395b9c7eb8071de2f0f32a273ea4d36fa03
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248981
-      name: ose-metering-ansible-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: ose-metering-ansible-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      - digest: sha256:ba151c6f9fa29414b5aa0163fe4a2176c6eb6b9bbc32a98d27ece6fbb9fa00c0
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248981
-      name: ose-metering-ansible-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: ose-metering-ansible-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      - digest: sha256:92727964274c003c4e27f6f55ab3ebae2f96c7225511ece3061714f82368aa09
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248981
-      name: ose-metering-ansible-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: ose-metering-ansible-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      - digest: sha256:6818dad3b9da5bbc6b728f6f5590467fd34c37f3a1a5e2c9f3aabeef84fed12f
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248981
-      name: ose-metering-ansible-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: ose-metering-ansible-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      - digest: sha256:e010ea8e6a50e917a7884d971aafc06d783ae69fe7c40a372e7bc7acf7cf273b
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248956
-      name: ose-ptp-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-ptp-operator-metadata:v4.3
-    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: ose-ptp-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      - digest: sha256:f644b80c1a21401eb1fa79b6e2732db05818562850c6d9acb41413d4b1524847
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248956
-      name: ose-ptp-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-ptp-operator-metadata:v4.3
-    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c2-vm-02.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: ose-ptp-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      - digest: sha256:d063d90f70fbfd210175023f564b1cfccebf52cda6fab7f9ab606e08a4095771
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248956
-      name: ose-ptp-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-ptp-operator-metadata:v4.3
-    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1008.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: ose-ptp-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      - digest: sha256:a5d2edb02c21c769ed90593520511f954d9de63680e338bc457fc2289b9725a3
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: arm64
@@ -1610,207 +1810,7 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-76837-20200707072220-aarch64
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248969
-      name: sriov-network-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: sriov-network-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      - digest: sha256:1bf775f662528cbbbab881b78eabbff551c27f5c678429ec87feff3cc84bd87d
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
-    src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248969
-      name: sriov-network-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: sriov-network-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      - digest: sha256:00a74f6340dc8defd262b67e02c596e6ec7ad40238943fd5cc2bb911caf1a0de
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
-    src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248969
-      name: sriov-network-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: sriov-network-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      - digest: sha256:b114fc0ff28650327a061d944ccc0ed4c20d16f32a826d8748b32439807e714f
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
-    src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248969
-      name: sriov-network-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - redhat-openshift4-ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: sriov-network-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      - digest: sha256:ab5ea2465f9d924c9f0e30a74ab57990dab383271c19dde33f35ec397be0386c
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
-    src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
+    src: null
     state: PENDING
 - ErratumPushItem:
     build: null
@@ -1925,7 +1925,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -1941,7 +1941,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -1957,7 +1957,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -1973,7 +1973,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -1989,7 +1989,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -2005,7 +2005,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -2021,7 +2021,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -2037,5 +2037,5 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING

--- a/tests/baseline/cases/errata-containers.yml
+++ b/tests/baseline/cases/errata-containers.yml
@@ -9,136 +9,36 @@ url: "erratatest:errata=RHBA-2020:2807"
 # Push items generated from above.
 items:
 - ContainerImagePushItem:
-    arch: s390x
-    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248993
-      name: cluster-logging-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-03.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: cluster-logging-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      - digest: sha256:5748c3cfdc9c493f1538d55137a84c25560e4344f097314d9e12b838c0bba189
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248993
-      name: cluster-logging-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: cluster-logging-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      - digest: sha256:759da12e95ff57da1e0c83ee534f78a2292b79c1bf288e40ff1cb256d42440a7
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
     arch: amd64
-    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
     build_info:
-      id: 1248993
-      name: cluster-logging-operator-metadata-container
+      id: 1248969
+      name: sriov-network-operator-metadata-container
       release: '1'
       version: v4.3.28.202006290519.p0.prod
     dest:
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
     dest_signing_key: 199e2f91fd431d51
     labels:
-      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
       com.redhat.delivery.appregistry: 'true'
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
-    name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
+    name: docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
     origin: RHBA-2020:2807
     pull_info:
       digest_specs:
-      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
         media_type: application/vnd.docker.distribution.manifest.list.v2+json
         registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      - digest: sha256:f5453808b4231f2b1e3121c8d302ed755475a76154ae353b49381966830c9a18
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      - digest: sha256:1bf775f662528cbbbab881b78eabbff551c27f5c678429ec87feff3cc84bd87d
         media_type: application/vnd.docker.distribution.manifest.v2+json
         registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
       media_types:
       - application/vnd.docker.distribution.manifest.list.v2+json
       - application/vnd.docker.distribution.manifest.v2+json
@@ -146,267 +46,17 @@ items:
       - media_types:
         - application/vnd.docker.distribution.manifest.list.v2+json
         registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
       - media_types: []
         registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
     sha256sum: null
     signing_key: null
     source_tags:
-    - rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248993
-      name: cluster-logging-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-06.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: cluster-logging-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      - digest: sha256:a279d2c29442bfa73550c428c30b058632e0656502ace41f7fffb8c44ed5b9fe
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248998
-      name: cluster-nfd-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: cluster-nfd-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      - digest: sha256:64e2392a10efacb98ab79db839babe4031f6ff94f832c7ab5ca52d1d6e124ea6
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248998
-      name: cluster-nfd-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: cluster-nfd-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      - digest: sha256:76c416c5dd128cb95f84c5ae277dd954bee390b2ad2e77d295aa01af5cf3b203
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248998
-      name: cluster-nfd-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: cluster-nfd-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      - digest: sha256:7d24896df49bf8969d9e92b177ca44dce42dc8878f4a8bb4073e1a245e6e8b24
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248998
-      name: cluster-nfd-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: cluster-nfd-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      - digest: sha256:edf7feb928d85e0b8d2c64bdcd893c9a149f6767beb10579a051714b9e7c2503
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
+    - rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: ppc64le
@@ -456,7 +106,157 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-80524-20200707075228-ppc64le
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248969
+      name: sriov-network-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      - digest: sha256:00a74f6340dc8defd262b67e02c596e6ec7ad40238943fd5cc2bb911caf1a0de
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248981
+      name: ose-metering-ansible-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      - digest: sha256:ba151c6f9fa29414b5aa0163fe4a2176c6eb6b9bbc32a98d27ece6fbb9fa00c0
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248981
+      name: ose-metering-ansible-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      - digest: sha256:92727964274c003c4e27f6f55ab3ebae2f96c7225511ece3061714f82368aa09
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: arm64
@@ -506,307 +306,7 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-50417-20200707075226-aarch64
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248994
-      name: elasticsearch-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3
-    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-02.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: elasticsearch-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:a595bff056e37d4d61cc9225504bf7f969adcdd53f8f5180176b612c17ceaedc
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-      - digest: sha256:d6d01ef696e32c0a6a177c6098550e3583208841462489669006700e33da1fe7
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-57368-20200707075038
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248994
-      name: elasticsearch-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3
-    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: elasticsearch-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:a595bff056e37d4d61cc9225504bf7f969adcdd53f8f5180176b612c17ceaedc
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-      - digest: sha256:f205a649e55b8757792a4d96ca5cfdadf6d717a11916fb47abb6fae623ff9e10
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-57368-20200707075038
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248963
-      name: local-storage-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: local-storage-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      - digest: sha256:482031ade5610ae584e5c75f844ad8139b4b18a6b7525a29517f5e4cbaf1646b
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248963
-      name: local-storage-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: local-storage-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      - digest: sha256:30f197a9de12601460d006e1f8b33e66fe355a46de75cf11c959df8bfc9bdaaa
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248963
-      name: local-storage-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c2-vm-03.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: local-storage-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      - digest: sha256:4e3e4ece862f9bb5ff473efb637c47ebb4916d5925270495583f86d19d22bbf8
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248963
-      name: local-storage-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c2-vm-03.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: local-storage-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      - digest: sha256:53fb41caedbff04e8ed8b7fab5ec761214c0578303080820223d54282ea95f5a
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: arm64
@@ -857,7 +357,457 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-46533-20200707080442-aarch64
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248956
+      name: ose-ptp-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-ptp-operator-metadata:v4.3
+    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      - digest: sha256:f644b80c1a21401eb1fa79b6e2732db05818562850c6d9acb41413d4b1524847
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248993
+      name: cluster-logging-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      - digest: sha256:5748c3cfdc9c493f1538d55137a84c25560e4344f097314d9e12b838c0bba189
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-13969-20200707075057-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248994
+      name: elasticsearch-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3
+    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-02.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:a595bff056e37d4d61cc9225504bf7f969adcdd53f8f5180176b612c17ceaedc
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+      - digest: sha256:d6d01ef696e32c0a6a177c6098550e3583208841462489669006700e33da1fe7
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-57368-20200707075038
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-10148-20200707075227-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248997
+      name: openshift-enterprise-template-service-broker-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      - digest: sha256:ea0ee5a340f99259c725dec0c2bafd10f569ffb8223db5c73d3f52e7df446058
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248963
+      name: local-storage-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      - digest: sha256:482031ade5610ae584e5c75f844ad8139b4b18a6b7525a29517f5e4cbaf1646b
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50813-20200707072548-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248994
+      name: elasticsearch-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3
+    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-elasticsearch-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: elasticsearch-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:a595bff056e37d4d61cc9225504bf7f969adcdd53f8f5180176b612c17ceaedc
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+      - digest: sha256:f205a649e55b8757792a4d96ca5cfdadf6d717a11916fb47abb6fae623ff9e10
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-57368-20200707075038
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-elasticsearch-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-39763-20200707075226-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248997
+      name: openshift-enterprise-template-service-broker-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      - digest: sha256:332c4e13f2d0329d03fea2702b71070c2d4bbfe1f6753e6a963d0aa41a08086e
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248997
+      name: openshift-enterprise-template-service-broker-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-04.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      - digest: sha256:6d76d7291e57bf0236bd14ef6a786d4b5140553443172595a6a60a6b6b340a7e
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248956
+      name: ose-ptp-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-ptp-operator-metadata:v4.3
+    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c2-vm-02.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      - digest: sha256:d063d90f70fbfd210175023f564b1cfccebf52cda6fab7f9ab606e08a4095771
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: ppc64le
@@ -908,7 +858,557 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-13114-20200707080444-ppc64le
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248981
+      name: ose-metering-ansible-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      - digest: sha256:6818dad3b9da5bbc6b728f6f5590467fd34c37f3a1a5e2c9f3aabeef84fed12f
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248969
+      name: sriov-network-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      - digest: sha256:b114fc0ff28650327a061d944ccc0ed4c20d16f32a826d8748b32439807e714f
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248998
+      name: cluster-nfd-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      - digest: sha256:64e2392a10efacb98ab79db839babe4031f6ff94f832c7ab5ca52d1d6e124ea6
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-37648-20200707075920-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248969
+      name: sriov-network-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: sriov-network-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      - digest: sha256:ab5ea2465f9d924c9f0e30a74ab57990dab383271c19dde33f35ec397be0386c
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248963
+      name: local-storage-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      - digest: sha256:30f197a9de12601460d006e1f8b33e66fe355a46de75cf11c959df8bfc9bdaaa
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-50460-20200707072547-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248956
+      name: ose-ptp-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-ptp-operator-metadata:v4.3
+    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1008.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: ose-ptp-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      - digest: sha256:a5d2edb02c21c769ed90593520511f954d9de63680e338bc457fc2289b9725a3
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ptp-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248998
+      name: cluster-nfd-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      - digest: sha256:76c416c5dd128cb95f84c5ae277dd954bee390b2ad2e77d295aa01af5cf3b203
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-31452-20200707075921-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248993
+      name: cluster-logging-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      - digest: sha256:759da12e95ff57da1e0c83ee534f78a2292b79c1bf288e40ff1cb256d42440a7
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-20098-20200707075056-aarch64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248998
+      name: cluster-nfd-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      - digest: sha256:7d24896df49bf8969d9e92b177ca44dce42dc8878f4a8bb4073e1a245e6e8b24
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-23776-20200707075920-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: amd64
+    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248993
+      name: cluster-logging-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: cpt-1005.osbs.prod.upshift.rdu2.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      - digest: sha256:f5453808b4231f2b1e3121c8d302ed755475a76154ae353b49381966830c9a18
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-78708-20200707075057-x86_64
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248981
+      name: ose-metering-ansible-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: ose-metering-ansible-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      - digest: sha256:e010ea8e6a50e917a7884d971aafc06d783ae69fe7c40a372e7bc7acf7cf273b
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: amd64
@@ -959,7 +1459,257 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-12704-20200707080441-x86_64
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248993
+      name: cluster-logging-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-cluster-logging-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c1-vm-06.prod.osbs.eng.rdu2.redhat.com
+      com.redhat.component: cluster-logging-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:e38da0971a67c6b3d4261edd9bd679de1be15d0716d208cddf54b0478a73f0a2
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      - digest: sha256:a279d2c29442bfa73550c428c30b058632e0656502ace41f7fffb8c44ed5b9fe
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-56520-20200707074906
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-logging-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-40827-20200707075058-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: ppc64le
+    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248963
+      name: local-storage-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: ppc64le-c2-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      - digest: sha256:4e3e4ece862f9bb5ff473efb637c47ebb4916d5925270495583f86d19d22bbf8
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-85934-20200707072549-ppc64le
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248963
+      name: local-storage-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-local-storage-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c2-vm-03.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: local-storage-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:440f56c49b3a3b7490716e5370eacf684529f950f79527016bb265073ffd5332
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      - digest: sha256:53fb41caedbff04e8ed8b7fab5ec761214c0578303080820223d54282ea95f5a
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-33656-20200707072400
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-local-storage-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-31634-20200707072549-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: s390x
+    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248997
+      name: openshift-enterprise-template-service-broker-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      - digest: sha256:f65555acb07c7e0c590389f55a16a395b9c7eb8071de2f0f32a273ea4d36fa03
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
+    src: null
+    state: PENDING
+- ContainerImagePushItem:
+    arch: arm64
+    build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
+    build_info:
+      id: 1248998
+      name: cluster-nfd-operator-metadata-container
+      release: '1'
+      version: v4.3.28.202006290519.p0.prod
+    dest:
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
+    - openshift4/ose-cluster-nfd-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
+    dest_signing_key: 199e2f91fd431d51
+    labels:
+      com.redhat.build-host: arm64-osbs-13.prod.osbs.eng.bos.redhat.com
+      com.redhat.component: cluster-nfd-operator-metadata-container
+      com.redhat.delivery.appregistry: 'true'
+      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
+    md5sum: null
+    name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
+    origin: RHBA-2020:2807
+    pull_info:
+      digest_specs:
+      - digest: sha256:625ed0e36cff8819aabaadfc67e983ba4486c3ab2c73286fe7bc1726ae08e2c4
+        media_type: application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      - digest: sha256:edf7feb928d85e0b8d2c64bdcd893c9a149f6767beb10579a051714b9e7c2503
+        media_type: application/vnd.docker.distribution.manifest.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+      media_types:
+      - application/vnd.docker.distribution.manifest.list.v2+json
+      - application/vnd.docker.distribution.manifest.v2+json
+      tag_specs:
+      - media_types:
+        - application/vnd.docker.distribution.manifest.list.v2+json
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-65305-20200707075731
+      - media_types: []
+        registry: registry-proxy.engineering.redhat.com
+        repository: rh-osbs/openshift-ose-cluster-nfd-operator-metadata
+        tag: rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
+    sha256sum: null
+    signing_key: null
+    source_tags:
+    - rhaos-4.3-rhel-7-candidate-97582-20200707075920-aarch64
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: s390x
@@ -1010,557 +1760,7 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-48676-20200707080442-s390x
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248997
-      name: openshift-enterprise-template-service-broker-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      - digest: sha256:ea0ee5a340f99259c725dec0c2bafd10f569ffb8223db5c73d3f52e7df446058
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-29839-20200707075658-x86_64
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248997
-      name: openshift-enterprise-template-service-broker-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      - digest: sha256:332c4e13f2d0329d03fea2702b71070c2d4bbfe1f6753e6a963d0aa41a08086e
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-34026-20200707075658-aarch64
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248997
-      name: openshift-enterprise-template-service-broker-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-04.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      - digest: sha256:6d76d7291e57bf0236bd14ef6a786d4b5140553443172595a6a60a6b6b340a7e
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-62041-20200707075700-ppc64le
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248997
-      name: openshift-enterprise-template-service-broker-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-template-service-broker-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: openshift-enterprise-template-service-broker-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:2e3b45e6ca30acddd1058a026b1a3fd47fbb02120e7e48b207954307dac53535
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      - digest: sha256:f65555acb07c7e0c590389f55a16a395b9c7eb8071de2f0f32a273ea4d36fa03
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-98159-20200707075510
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-openshift-enterprise-template-service-broker-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-35990-20200707075659-s390x
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248981
-      name: ose-metering-ansible-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-12.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: ose-metering-ansible-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      - digest: sha256:ba151c6f9fa29414b5aa0163fe4a2176c6eb6b9bbc32a98d27ece6fbb9fa00c0
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-73090-20200707074057-aarch64
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248981
-      name: ose-metering-ansible-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: ose-metering-ansible-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      - digest: sha256:92727964274c003c4e27f6f55ab3ebae2f96c7225511ece3061714f82368aa09
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-37981-20200707074058-s390x
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248981
-      name: ose-metering-ansible-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1002.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: ose-metering-ansible-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      - digest: sha256:6818dad3b9da5bbc6b728f6f5590467fd34c37f3a1a5e2c9f3aabeef84fed12f
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-37691-20200707074057-x86_64
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248981
-      name: ose-metering-ansible-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-metering-ansible-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-03.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: ose-metering-ansible-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:5c27155eaec4c610bc8389f7068c4713fcf6148097479f8e1fa8a12d5f3cad75
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      - digest: sha256:e010ea8e6a50e917a7884d971aafc06d783ae69fe7c40a372e7bc7acf7cf273b
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-80281-20200707073911
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ose-metering-ansible-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-65912-20200707074059-ppc64le
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248956
-      name: ose-ptp-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-ptp-operator-metadata:v4.3
-    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c2-vm-04.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: ose-ptp-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      - digest: sha256:f644b80c1a21401eb1fa79b6e2732db05818562850c6d9acb41413d4b1524847
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-55835-20200707072221-s390x
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248956
-      name: ose-ptp-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-ptp-operator-metadata:v4.3
-    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c2-vm-02.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: ose-ptp-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      - digest: sha256:d063d90f70fbfd210175023f564b1cfccebf52cda6fab7f9ab606e08a4095771
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-22606-20200707072222-ppc64le
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248956
-      name: ose-ptp-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-ptp-operator-metadata:v4.3
-    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-ptp-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1008.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: ose-ptp-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:9e7f37ad9893d218c9998e53bdb847505c103999200a36afa9fd0875facd7643
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      - digest: sha256:a5d2edb02c21c769ed90593520511f954d9de63680e338bc457fc2289b9725a3
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-15503-20200707071931
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-ptp-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-11742-20200707072220-x86_64
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
+    src: null
     state: PENDING
 - ContainerImagePushItem:
     arch: arm64
@@ -1610,207 +1810,7 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.3-rhel-7-candidate-76837-20200707072220-aarch64
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: amd64
-    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248969
-      name: sriov-network-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: cpt-1006.osbs.prod.upshift.rdu2.redhat.com
-      com.redhat.component: sriov-network-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      - digest: sha256:1bf775f662528cbbbab881b78eabbff551c27f5c678429ec87feff3cc84bd87d
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-96350-20200707073241-x86_64
-    src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: ppc64le
-    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248969
-      name: sriov-network-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: ppc64le-c1-vm-05.prod.osbs.eng.rdu2.redhat.com
-      com.redhat.component: sriov-network-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      - digest: sha256:00a74f6340dc8defd262b67e02c596e6ec7ad40238943fd5cc2bb911caf1a0de
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-26015-20200707073243-ppc64le
-    src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: s390x
-    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248969
-      name: sriov-network-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: s390-c1-vm-05.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: sriov-network-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      - digest: sha256:b114fc0ff28650327a061d944ccc0ed4c20d16f32a826d8748b32439807e714f
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-12128-20200707073242-s390x
-    src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
-    state: PENDING
-- ContainerImagePushItem:
-    arch: arm64
-    build: sriov-network-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
-    build_info:
-      id: 1248969
-      name: sriov-network-operator-metadata-container
-      release: '1'
-      version: v4.3.28.202006290519.p0.prod
-    dest:
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod
-    - openshift4/ose-sriov-network-rhel7-operator-metadata:v4.3.28.202006290519.p0.prod-1
-    dest_signing_key: 199e2f91fd431d51
-    labels:
-      com.redhat.build-host: arm64-osbs-14.prod.osbs.eng.bos.redhat.com
-      com.redhat.component: sriov-network-operator-metadata-container
-      com.redhat.delivery.appregistry: 'true'
-      com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
-    md5sum: null
-    name: docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
-    origin: RHBA-2020:2807
-    pull_info:
-      digest_specs:
-      - digest: sha256:16a04fde191ebd8858fa7f97605a9783be570e37d329eec599cfecf03b5cd8f2
-        media_type: application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      - digest: sha256:ab5ea2465f9d924c9f0e30a74ab57990dab383271c19dde33f35ec397be0386c
-        media_type: application/vnd.docker.distribution.manifest.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-      media_types:
-      - application/vnd.docker.distribution.manifest.list.v2+json
-      - application/vnd.docker.distribution.manifest.v2+json
-      tag_specs:
-      - media_types:
-        - application/vnd.docker.distribution.manifest.list.v2+json
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-88311-20200707073051
-      - media_types: []
-        registry: registry-proxy.engineering.redhat.com
-        repository: rh-osbs/openshift-ose-sriov-network-operator-metadata
-        tag: rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
-    sha256sum: null
-    signing_key: null
-    source_tags:
-    - rhaos-4.3-rhel-7-candidate-30090-20200707073241-aarch64
-    src: {{ koji_dir }}/packages/sriov-network-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/images/docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
+    src: null
     state: PENDING
 - ErratumPushItem:
     build: null
@@ -1925,7 +1925,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/cluster-logging-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -1941,7 +1941,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/cluster-nfd-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -1957,7 +1957,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/elasticsearch-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -1973,7 +1973,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/local-storage-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -1989,7 +1989,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/openshift-enterprise-ansible-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -2005,7 +2005,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/openshift-enterprise-template-service-broker-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -2021,7 +2021,7 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/ose-metering-ansible-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1
@@ -2037,5 +2037,5 @@ items:
     related_images: []
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/ose-ptp-operator-metadata-container/v4.3.28.202006290519.p0.prod/1/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING

--- a/tests/baseline/cases/koji-operator-container.yml
+++ b/tests/baseline/cases/koji-operator-container.yml
@@ -54,7 +54,7 @@ items:
     signing_key: null
     source_tags:
     - rhaos-4.11-rhel-8-containers-candidate-46533-20230301150354-x86_64
-    src: {{ koji_dir }}/packages/security-profiles-operator-bundle-container/0.5.2/2/images/docker-image-sha256:eb6788bfdcb4c1743176a99440754e925725664e037180ab974fd64a238fae29.x86_64.tar.gz
+    src: null
     state: PENDING
 - OperatorManifestPushItem:
     build: security-profiles-operator-bundle-container-0.5.2-2
@@ -73,5 +73,5 @@ items:
     - registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:5df77deac108236c8d3fc84bfaae9f86439557ccb9a08b9cd4fac7ce4e918485
     sha256sum: null
     signing_key: null
-    src: {{ koji_dir }}/packages/security-profiles-operator-bundle-container/0.5.2/2/files/operator-manifests/operator_manifests.zip
+    src: null
     state: PENDING

--- a/tests/baseline/cases/koji-source-container.yml
+++ b/tests/baseline/cases/koji-source-container.yml
@@ -39,5 +39,5 @@ items:
     signing_key: null
     source_tags:
     - rhos-16.1-rhel-8-containers-candidate-83243-20210621202300-x86_64
-    src: {{ koji_dir }}/packages/openstack-swift-container-container-source/16.1.6/6.1/images/docker-image-sha256:bfe520f7c81aeb3eaeb732ab93dd76b279b6a01a16a27f1ec34d5b2fcefbb363.x86_64.tar.gz
+    src: null
     state: PENDING


### PR DESCRIPTION
Since container pushes were switched to Quay, this field is no longer used. However, the file's presence in the mounted volumes is still being polled before the push can begin. This can cause the pushes to take much longer than necessary. Remove the field so that the unnecessary wait is skipped.