### PR TITLE
Allow Errata HTTP client to work without Kerberos credentials

### DIFF
--- a/src/pushsource/_impl/backend/errata_source/errata_http_client.py
+++ b/src/pushsource/_impl/backend/errata_source/errata_http_client.py
@@ -5,6 +5,7 @@ import re
 import logging
 import tempfile
 from urllib.parse import urljoin
+from functools import wraps
 
 import requests
 import gssapi
@@ -12,6 +13,14 @@ import requests_gssapi
 
 LOG = logging.getLogger("pushsource.errata_http_client")
 
+def return_none_if_unauthenticated(func):
+    @wraps(func)
+    def wrapper_return_none_if_unauthenticated(self, *args, **kwargs):
+        if not self.keytab_path or not self.principal:
+            return None
+        return func(self, *args, **kwargs)
+
+    return wrapper_return_none_if_unauthenticated
 
 class ErrataHTTPClient:
     """Class for performing HTTP API queries with Errata."""
@@ -123,6 +132,7 @@ class ErrataHTTPClient:
 
         return self._thread_local.session
 
+    @return_none_if_unauthenticated
     def get_advisory_data(self, advisory: str) -> dict:
         """
         Get advisory data.

--- a/src/pushsource/_impl/backend/errata_source/errata_http_client.py
+++ b/src/pushsource/_impl/backend/errata_source/errata_http_client.py
@@ -13,6 +13,7 @@ import requests_gssapi
 
 LOG = logging.getLogger("pushsource.errata_http_client")
 
+
 def return_none_if_unauthenticated(func):
     @wraps(func)
     def wrapper_return_none_if_unauthenticated(self, *args, **kwargs):
@@ -21,6 +22,7 @@ def return_none_if_unauthenticated(func):
         return func(self, *args, **kwargs)
 
     return wrapper_return_none_if_unauthenticated
+
 
 class ErrataHTTPClient:
     """Class for performing HTTP API queries with Errata."""

--- a/src/pushsource/_impl/backend/errata_source/errata_source.py
+++ b/src/pushsource/_impl/backend/errata_source/errata_source.py
@@ -239,9 +239,12 @@ class ErrataSource(Source):
 
         # Get product name from Errata. Enrich Container push items with this info
         advisory_data = self._http_client.get_advisory_data(erratum.name)
-        # This dictionary key is different based on erratum type
-        erratum_type = list(advisory_data["errata"].keys())[0]
-        product_name = advisory_data["errata"][erratum_type]["product"]["name"]
+        if advisory_data:
+            # This dictionary key is different based on erratum type
+            erratum_type = list(advisory_data["errata"].keys())[0]
+            product_name = advisory_data["errata"][erratum_type]["product"]["name"]
+        else:
+            product_name = None
 
         # We'll be getting container metadata from these builds.
         with self._koji_source(

--- a/tests/baseline/test_baseline.py
+++ b/tests/baseline/test_baseline.py
@@ -86,9 +86,21 @@ def koji_test_backend(fake_koji, koji_dir):
 
 @pytest.fixture(autouse=True)
 def fake_kerberos_auth(mocker):
+    mocker.patch(
+        "pushsource._impl.backend.errata_source."
+        "errata_http_client.ErrataHTTPClient.create_kerberos_ticket"
+    )
     mocker.patch("gssapi.Name")
     mocker.patch("gssapi.Credentials.acquire")
     mocker.patch("requests_gssapi.HTTPSPNEGOAuth", return_value=None)
+    with patch.dict(
+        "os.environ",
+        {
+            "PUSHSOURCE_ERRATA_KEYTAB_PATH": "/path/to/keytab",
+            "PUSHSOURCE_ERRATA_PRINCIPAL": "pub-errata@IPA.REDHAT.COM",
+        },
+    ):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/errata/test_errata_http_client.py
+++ b/tests/errata/test_errata_http_client.py
@@ -243,3 +243,14 @@ def test_get_advisory_data(caplog):
         "Queried Errata HTTP API for RHSA-123456789",
         "GET https://errata.example.com/api/v1/erratum/RHSA-123456789 200",
     ]
+
+
+def test_get_advisory_data_no_credentials(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    client = ErrataHTTPClient("https://errata.example.com/")
+
+    data = client.get_advisory_data("RHSA-123456789")
+
+    assert data == None
+    assert caplog.messages == []


### PR DESCRIPTION
If credentials are not specified, the HTTP method returns None without querying the endpoint. This change was made because the Errata Kerberos credentials are not yet prepared and the gathered information is not yet necessary.

This unusual feature should be removed in the future.