### PR TITLE
Add attribute "marketplace_title" to VMIRelease

### DIFF
--- a/src/pushsource/_impl/model/ami.py
+++ b/src/pushsource/_impl/model/ami.py
@@ -220,6 +220,8 @@ class AmiPushItem(VMIPushItem):
             "scanning_port": data.get("scanning_port") or None,
             "user_name": data.get("user_name") or None,
             "version_title": data.get("version_title") or None,
+            "marketplace_title_template": data.get("marketplace_title_template")
+            or None,
             "security_groups": [
                 AmiSecurityGroup._from_data(security_group)
                 for security_group in (data.get("security_groups") or [])

--- a/src/pushsource/_impl/model/vms.py
+++ b/src/pushsource/_impl/model/vms.py
@@ -3,6 +3,7 @@ import enum
 
 from .base import PushItem
 from .. import compat_attr as attr
+from attr import asdict
 from .conv import datestr, instance_of_str, instance_of, optional_str, optional, in_
 
 
@@ -73,6 +74,22 @@ class VMIPushItem(PushItem):
 
     boot_mode = attr.ib(type=BootMode, default=None, validator=optional(in_(BootMode)))
     """Boot mode supported by the image (if known): uefi, legacy, or hybrid (uefi + legacy)."""
+
+    marketplace_title_template = attr.ib(type=str, default=None, validator=optional_str)
+    """The template is of the form used by ``str.format``, with available keywords being all of
+    the documented fields on ``VMIRelease`` and ``AMIRelease`` classes.
+    
+    It's used by the property `marketplace_title` to format it as the marketplace title."""
+
+    @property
+    def marketplace_title(self) -> str:
+        """The marketplace title which is used for some certain layared products.
+
+        It's built from the `marketplace_title_template` by formatting it with the proper values.
+        """
+        if not self.marketplace_title_template or not self.release:
+            return ""
+        return self.marketplace_title_template.format(**asdict(self.release))
 
     @release.validator
     def __validate_release(self, attribute, value):  # pylint: disable=unused-argument

--- a/src/pushsource/_impl/model/vms.py
+++ b/src/pushsource/_impl/model/vms.py
@@ -83,7 +83,7 @@ class VMIPushItem(PushItem):
 
     @property
     def marketplace_title(self) -> str:
-        """The marketplace title which is used for some certain layared products.
+        """The marketplace title which is used for some certain layered products.
 
         It's built from the `marketplace_title_template` by formatting it with the proper values.
         """

--- a/src/pushsource/_impl/schema/staged-schema.yaml
+++ b/src/pushsource/_impl/schema/staged-schema.yaml
@@ -135,6 +135,8 @@ definitions:
                 $ref: "#/definitions/optional_string"
             version_title:
                 $ref: "#/definitions/optional_string"
+            marketplace_title_template:
+                $ref: "#/definitions/optional_string"
             security_groups:
                 type:
                     - array

--- a/tests/baseline/cases/staged-simple-ami-bc.yml
+++ b/tests/baseline/cases/staged-simple-ami-bc.yml
@@ -23,6 +23,7 @@ items:
     ena_support: true
     image_id: null
     marketplace_entity_type: AMIProduct
+    marketplace_title_template: null
     md5sum: null
     name: fake-image.raw
     origin: {{ src_dir }}/tests/staged/data/simple_ami_with_bc

--- a/tests/baseline/cases/staged-simple-ami-bootmode.yml
+++ b/tests/baseline/cases/staged-simple-ami-bootmode.yml
@@ -19,6 +19,7 @@ items:
     ena_support: true
     image_id: null
     marketplace_entity_type: null
+    marketplace_title_template: null
     md5sum: null
     name: fake-image.raw
     origin: {{ src_dir }}/tests/staged/data/simple_ami_with_bootmode

--- a/tests/baseline/cases/staged-simple-ami-uefi.yml
+++ b/tests/baseline/cases/staged-simple-ami-uefi.yml
@@ -19,6 +19,7 @@ items:
     ena_support: true
     image_id: null
     marketplace_entity_type: null
+    marketplace_title_template: null
     md5sum: null
     name: fake-image.raw
     origin: {{ src_dir }}/tests/staged/data/simple_ami_with_uefi

--- a/tests/baseline/cases/staged-simple-ami.yml
+++ b/tests/baseline/cases/staged-simple-ami.yml
@@ -19,6 +19,7 @@ items:
     ena_support: true
     image_id: null
     marketplace_entity_type: null
+    marketplace_title_template: null
     md5sum: null
     name: fake-image.raw
     origin: {{ src_dir }}/tests/staged/data/simple_ami

--- a/tests/model/test_vmi.py
+++ b/tests/model/test_vmi.py
@@ -1,6 +1,6 @@
 from pytest import raises
 
-from pushsource import VMIRelease
+from pushsource import VMIRelease, VMIPushItem
 
 
 def test_invalidate_datestr():
@@ -9,3 +9,36 @@ def test_invalidate_datestr():
         VMIRelease(product="myprod", arch="x86_64", respin=1, date="not-a-real-date")
 
     assert "can't parse 'not-a-real-date' as a date" in str(exc_info.value)
+
+
+def test_marketplace_title():
+    """Ensure the marketplace_title is properly formed from the template."""
+
+    release = VMIRelease(
+        product="myprod", arch="x86_64", version="7.0", respin=1, date="20240101"
+    )
+
+    # Template provided
+    template = r"Test {product} {arch} {version} - success"
+    pi = VMIPushItem(
+        description="mydescription",
+        name="myname",
+        marketplace_title_template=template,
+        release=release,
+    )
+    assert pi.marketplace_title == "Test myprod x86_64 7.0 - success"
+
+    # No template provided
+    pi = VMIPushItem(
+        description="mydescription",
+        name="myname",
+        release=release,
+    )
+    assert pi.marketplace_title == ""
+
+    # No release provided
+    pi = VMIPushItem(
+        description="mydescription",
+        name="myname",
+    )
+    assert pi.marketplace_title == ""

--- a/tests/staged/data/simple_ami/staged.yaml
+++ b/tests/staged/data/simple_ami/staged.yaml
@@ -25,3 +25,4 @@ payload:
       virtualization: hvm
       volume: gp2
       public_image: true
+      marketplace_title_template: "Test {product} - {date}"


### PR DESCRIPTION
This commit introduces a new optional parameter on `VMIRelease` and `AmiRelease` models called `marketplace_title` which is going to be used by the pubtool as the marketplace "version title" whenever it's set, by overriding the usual version title which the pubtool was going to compute.

This is required for some layered products which requires a specialized templating title instead of the one generated by the pubtool.

With this, it will be possible to transport the template via the VMIPushItem from the source to the pubtooling which will format it into the apropriate value for the marketaplace.

Refers to SPSTRAT-116