### PR TITLE
Fix importing version from importlib.metadata for py<3.8

### DIFF
--- a/src/pushsource/_impl/compat_attr.py
+++ b/src/pushsource/_impl/compat_attr.py
@@ -1,5 +1,12 @@
-from importlib.metadata import version
 import attr
+# importlib.metadata is available for py3.8 and higher
+# previous versions get it from importlib_metadata installed
+# from importlib-metadata
+try:
+  from importlib.metadata import version
+except ImportError:  # pragma: no cover
+  from importlib_metadata import version
+
 
 # Wrappers for attr module to deal with some incompatibilities between versions
 

--- a/src/pushsource/_impl/compat_attr.py
+++ b/src/pushsource/_impl/compat_attr.py
@@ -1,11 +1,12 @@
 import attr
+
 # importlib.metadata is available for py3.8 and higher
 # previous versions get it from importlib_metadata installed
 # from importlib-metadata
 try:
-  from importlib.metadata import version
+    from importlib.metadata import version
 except ImportError:  # pragma: no cover
-  from importlib_metadata import version
+    from importlib_metadata import version
 
 
 # Wrappers for attr module to deal with some incompatibilities between versions


### PR DESCRIPTION
importlib.metadata is available for py3.8 and later versions. This fails for py<3.8, however, it could be imported from importlib_metadata for previous versions. This patch makes it compatible for py<3.8 as the lib is used on RHEL/UBI8 with py3.6.