### PR TITLE
ci: drop codecov upload in this project

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -37,13 +37,6 @@ jobs:
         run: pip install tox
       - name: Run Tox
         run: tox -e cov
-      - name: Install pytest cov
-        run: pip install pytest-cov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: true
-          verbose: true
   docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
In this project, "tox -e cov" already runs pytest with `--cov-fail-under=100`, thus the coverage is always enforced to remain at 100%.

Sending the coverage data to a remote service seems of little value when the coverage is already enforced at 100% when the tests are run; in fact, we probably wouldn't even reach this step if the coverage was less than 100%, since tox should have failed.

It's a common source of CI flakiness, so just drop it.