### PR TITLE
README: fix outdated badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@ pushsource
 A Python library for collecting content from various sources, used by
 [release-engineering](https://github.com/release-engineering) publishing tools.
 
-[![Build Status](https://travis-ci.org/release-engineering/pushsource.svg?branch=master)](https://travis-ci.org/release-engineering/pushsource)
-[![Coverage Status](https://coveralls.io/repos/github/release-engineering/pushsource/badge.svg?branch=master)](https://coveralls.io/github/release-engineering/pushsource?branch=master)
+[![PyPI](https://img.shields.io/pypi/v/pushsource)](https://pypi.org/project/pushsource/)
+![Build Status](https://github.com/release-engineering/pushsource/actions/workflows/tox-test.yml/badge.svg)
 
 - [Source](https://github.com/release-engineering/pushsource)
 - [Documentation](https://release-engineering.github.io/pushsource/)
-- [PyPI](https://pypi.org/project/pushsource)
 
 
 Installation


### PR DESCRIPTION
- travis has not been used for testing for a long time. Replace with a github actions equivalent.
- coveralls has not been used for coverage reports for a long time. Drop it; there is no replacement as the testing workflow always enforces 100% coverage anyway.
- add a pypi badge to flesh things out a bit and show the latest release at a glance.