### PR TITLE
Retry brew requests [CLOUDDST-22680]

### DIFF
--- a/src/pushsource/_impl/backend/koji_source.py
+++ b/src/pushsource/_impl/backend/koji_source.py
@@ -248,7 +248,7 @@ class KojiSource(Source):
             tls = self._cache.setdefault("tls", threading.local())
             if not hasattr(tls, "koji_session"):
                 LOG.debug("Creating koji session: %s", self._url)
-                tls.koji_session = koji.ClientSession(self._url)
+                tls.koji_session = koji.ClientSession(self._url, {"anon_retry": True})
         return tls.koji_session
 
     def _koji_check(self):

--- a/tests/koji/fake_koji.py
+++ b/tests/koji/fake_koji.py
@@ -21,7 +21,7 @@ class FakeKojiController(object):
         self.last_url = None
         self.next_build_id = 80000
 
-    def session(self, url):
+    def session(self, url, opts=None):
         self.last_url = url
         return FakeKojiSession(self)
 

--- a/tests/koji/test_koji.py
+++ b/tests/koji/test_koji.py
@@ -26,7 +26,8 @@ def test_koji_empty(fake_koji):
     assert list(source) == []
 
 
-def test_koji_connect_error():
+@patch("time.sleep")
+def test_koji_connect_error(time_sleep):
     """Source raises a reasonable error if server can't be contacted"""
 
     # Note: fake_koji fixture not used here, so this will really try to connect


### PR DESCRIPTION
non-logged-in brew requests are not retried by default. Enable the retry to reduce push failures caused by brew connection issues.