### PR TITLE
Add optional property "cloud_info" for VMIs

### DIFF
--- a/docs/model/vmi.rst
+++ b/docs/model/vmi.rst
@@ -7,5 +7,8 @@ Push items: VMI
 .. autoclass:: pushsource.VMIRelease()
    :members:
 
+.. autoclass:: pushsource.VMICloudInformation()
+   :members:
+
 .. autoclass:: pushsource.BootMode()
    :members:

--- a/docs/model/vmi.rst
+++ b/docs/model/vmi.rst
@@ -7,7 +7,7 @@ Push items: VMI
 .. autoclass:: pushsource.VMIRelease()
    :members:
 
-.. autoclass:: pushsource.VMICloudInformation()
+.. autoclass:: pushsource.VMICloudInfo()
    :members:
 
 .. autoclass:: pushsource.BootMode()

--- a/src/pushsource/__init__.py
+++ b/src/pushsource/__init__.py
@@ -26,6 +26,7 @@ from pushsource._impl.model import (
     AmiBillingCodes,
     AmiSecurityGroup,
     VHDPushItem,
+    VMICloudInfo,
     BootMode,
     ErratumPushItem,
     ErratumReference,

--- a/src/pushsource/_impl/model/__init__.py
+++ b/src/pushsource/_impl/model/__init__.py
@@ -30,4 +30,4 @@ from .ami import (
     AmiSecurityGroup,
 )
 from .azure import VHDPushItem
-from .vms import BootMode, VMIPushItem, VMIRelease
+from .vms import BootMode, VMICloudInfo, VMIPushItem, VMIRelease

--- a/src/pushsource/_impl/model/ami.py
+++ b/src/pushsource/_impl/model/ami.py
@@ -2,7 +2,7 @@ from frozenlist2 import frozenlist
 
 from .. import compat_attr as attr
 from .conv import instance_of_str, instance_of, optional_str, optional
-from .vms import VMIRelease, VMIPushItem, BootMode
+from .vms import VMICloudInfo, VMIRelease, VMIPushItem, BootMode
 
 
 class AmiRelease(VMIRelease):
@@ -219,6 +219,11 @@ class AmiPushItem(VMIPushItem):
             # base push item fields
             "name": data["name"],
             "build": data.get("build") or None,
+            "cloud_info": (
+                VMICloudInfo(**data.get("cloud_info"))
+                if data.get("cloud_info")
+                else None
+            ),
             "state": "PENDING",
             "src": data.get("src") or None,
             "dest": data.get("dest") or [],

--- a/src/pushsource/_impl/model/vms.py
+++ b/src/pushsource/_impl/model/vms.py
@@ -104,7 +104,7 @@ class VMIPushItem(PushItem):
         default=None,
         validator=optional((instance_of(VMICloudInfo))),
     )
-    """Cloud provider information , such as the provider's short name and account alias."""
+    """Cloud provider information, such as the provider's short name and account alias."""
 
     marketplace_title_template = attr.ib(type=str, default=None, validator=optional_str)
     """The template is of the form used by ``str.format``, with available keywords being all of

--- a/src/pushsource/_impl/model/vms.py
+++ b/src/pushsource/_impl/model/vms.py
@@ -25,6 +25,26 @@ class BootMode(enum.Enum):
 
 
 @attr.s()
+class VMICloudInfo(object):
+    """Information on the cloud provider associated with a given push item.
+
+    Cloud provider information is only available for VMIs which have previously
+    been published to a cloud. It may be used to locate an existing VMI for
+    manipulation, such as metadata updates or deletion.
+
+    This library doesn't define any specific cloud provider names or aliases.
+    Generally, a user of this library is expected to use the information here
+    to look up cloud access details from a configuration file or other source.
+    """
+
+    provider = attr.ib(type=str, validator=instance_of_str)
+    """The cloud provider's name, e.g.: "aws"."""
+
+    account = attr.ib(type=str, validator=instance_of_str)
+    """The cloud provider's account alias, e.g.: "aws-na"."""
+
+
+@attr.s()
 class VMIRelease(object):
     """Release metadata associated with a VM image."""
 
@@ -78,6 +98,13 @@ class VMIPushItem(PushItem):
 
     boot_mode = attr.ib(type=BootMode, default=None, validator=optional(in_(BootMode)))
     """Boot mode supported by the image (if known): uefi, legacy, or hybrid (uefi + legacy)."""
+
+    cloud_info = attr.ib(
+        type=VMICloudInfo,
+        default=None,
+        validator=optional((instance_of(VMICloudInfo))),
+    )
+    """Cloud provider information , such as the provider's short name and account alias."""
 
     marketplace_title_template = attr.ib(type=str, default=None, validator=optional_str)
     """The template is of the form used by ``str.format``, with available keywords being all of

--- a/tests/baseline/cases/staged-simple-ami-bc.yml
+++ b/tests/baseline/cases/staged-simple-ami-bc.yml
@@ -18,6 +18,7 @@ items:
     boot_mode: null
     build: null
     build_info: null
+    cloud_info: null
     description: A sample image for testing
     dest:
     - dest1

--- a/tests/baseline/cases/staged-simple-ami-bootmode.yml
+++ b/tests/baseline/cases/staged-simple-ami-bootmode.yml
@@ -14,6 +14,7 @@ items:
     boot_mode: uefi
     build: null
     build_info: null
+    cloud_info: null
     description: A sample image for testing
     dest:
     - dest1

--- a/tests/baseline/cases/staged-simple-ami-uefi.yml
+++ b/tests/baseline/cases/staged-simple-ami-uefi.yml
@@ -14,6 +14,7 @@ items:
     boot_mode: null
     build: null
     build_info: null
+    cloud_info: null
     description: A sample image for testing
     dest:
     - dest1

--- a/tests/baseline/cases/staged-simple-ami.yml
+++ b/tests/baseline/cases/staged-simple-ami.yml
@@ -14,6 +14,7 @@ items:
     boot_mode: null
     build: null
     build_info: null
+    cloud_info: null
     description: A sample image for testing
     dest:
     - dest1

--- a/tests/baseline/cases/staged-simple-cloud.yml
+++ b/tests/baseline/cases/staged-simple-cloud.yml
@@ -18,6 +18,7 @@ items:
       name: rhel
       release: '1'
       version: '9.4'
+    cloud_info: null
     description: build2 sample
     dest:
     - starmap
@@ -68,6 +69,7 @@ items:
       name: rhel
       release: '1'
       version: '9.4'
+    cloud_info: null
     description: build2 sample
     dest:
     - starmap
@@ -118,6 +120,7 @@ items:
       name: rhel-ec2
       release: '1'
       version: '9.4'
+    cloud_info: null
     description: build3 sample
     dest:
     - starmap
@@ -166,6 +169,7 @@ items:
       name: rhel-ec2
       release: '1'
       version: '9.4'
+    cloud_info: null
     description: build1 sample
     dest:
     - starmap
@@ -203,6 +207,7 @@ items:
       name: rhel-ec2
       release: '1'
       version: '9.4'
+    cloud_info: null
     description: build1 sample
     dest:
     - starmap

--- a/tests/pub/data/100/images.json
+++ b/tests/pub/data/100/images.json
@@ -7,6 +7,10 @@
       ], 
       "name": "Hourly2"
     }, 
+    "cloud_info": {
+      "provider": "aws",
+      "account": "aws-emea"
+    },
     "description": "Provided by Red Hat, Inc.", 
     "dest": [
       "me-south-1-hourly"

--- a/tests/pub/data/123456/clouds.json
+++ b/tests/pub/data/123456/clouds.json
@@ -8,6 +8,10 @@
       "release": "2116",
       "version": "8.8"
     },
+    "cloud_info": {
+      "provider": "aws",
+      "account": "aws-emea"
+    },
     "description": "Provided by Red Hat, Inc.",
     "dest": [
       "test-dest"

--- a/tests/pub/data/123456/images.json
+++ b/tests/pub/data/123456/images.json
@@ -7,6 +7,10 @@
         ], 
         "name": "Hourly2"
       }, 
+      "cloud_info": {
+        "provider": "aws",
+        "account": "aws-emea"
+      },
       "description": "Provided by Red Hat, Inc.", 
       "dest": [
         "sa-east-1-hourly"

--- a/tests/pub/data/200/clouds.json
+++ b/tests/pub/data/200/clouds.json
@@ -8,6 +8,10 @@
       "release": "2116",
       "version": "8.8"
     },
+    "cloud_info": {
+      "provider": "aws",
+      "account": "aws-na"
+    },
     "description": "Provided by Red Hat, Inc.",
     "dest": [
       "test-dest"
@@ -145,6 +149,10 @@
       "release": "2116",
       "version": "8.8"
     },
+    "cloud_info": {
+      "provider": "aws",
+      "account": "aws-emea"
+    },
     "description": "Provided by Red Hat, Inc.",
     "dest": [
       "test-dest2"
@@ -279,6 +287,10 @@
         "bp-fake"
       ],
       "name": "Hourly2"
+    },
+    "cloud_info": {
+      "provider": "aws",
+      "account": "aws-emea"
     },
     "boot_mode": null,
     "build": "rhel-ec2-8.8-2175",

--- a/tests/pub/data/200/images.json
+++ b/tests/pub/data/200/images.json
@@ -7,6 +7,10 @@
       ], 
       "name": "Hourly2"
     }, 
+    "cloud_info": {
+      "provider": "aws",
+      "account": "aws-na"
+    },
     "description": "Provided by Red Hat, Inc.", 
     "dest": [
       "us-east-1-hourly"
@@ -48,6 +52,10 @@
       ], 
       "name": "Hourly2"
     }, 
+    "cloud_info": {
+      "provider": "aws",
+      "account": "aws-emea"
+    },
     "description": "Provided by Red Hat, Inc.", 
     "dest": [
       "me-central-1-hourly"

--- a/tests/pub/test_pub_amis.py
+++ b/tests/pub/test_pub_amis.py
@@ -13,6 +13,7 @@ from pushsource import (
     Source,
     AmiSecurityGroup,
     KojiBuildInfo,
+    VMICloudInfo,
 )
 
 DATAPATH = os.path.join(os.path.dirname(__file__), "data")
@@ -55,6 +56,7 @@ def test_get_ami_push_items_single_task(requests_mock):
             origin="/fake/path/aws/",
             build=None,
             build_info=None,
+            cloud_info=VMICloudInfo(provider="aws", account="aws-emea"),
             signing_key=None,
             release=AmiRelease(
                 product="SAP",
@@ -140,6 +142,7 @@ def test_get_ami_push_items_single_task_clouds(requests_mock):
                 release="2116",
                 id=None,
             ),
+            cloud_info=VMICloudInfo(provider="aws", account="aws-emea"),
             release=AmiRelease(
                 product="RHEL-SAP",
                 date="20240717",
@@ -211,6 +214,7 @@ def test_get_ami_push_items_rhcos_task_cloud(requests_mock):
                 release="2116",
                 id=None,
             ),
+            cloud_info=VMICloudInfo(provider="aws", account="aws-na"),
             release=AmiRelease(
                 product="RHEL-SAP",
                 date="20240717",
@@ -248,6 +252,7 @@ def test_get_ami_push_items_rhcos_task_cloud(requests_mock):
                 release="2116",
                 id=None,
             ),
+            cloud_info=VMICloudInfo(provider="aws", account="aws-emea"),
             image_id="ami-test",
             release=AmiRelease(
                 product="RHEL-SAP",
@@ -286,6 +291,7 @@ def test_get_ami_push_items_rhcos_task_cloud(requests_mock):
                 release="2175",
                 id=None,
             ),
+            cloud_info=VMICloudInfo(provider="aws", account="aws-emea"),
             image_id="ami-test",
             release=AmiRelease(
                 product="RHEL",
@@ -344,6 +350,7 @@ def test_get_ami_push_items_multiple_tasks(requests_mock):
             origin="/fake/path/aws",
             build=None,
             build_info=None,
+            cloud_info=VMICloudInfo(provider="aws", account="aws-emea"),
             signing_key=None,
             release=AmiRelease(
                 product="SAP",
@@ -378,6 +385,7 @@ def test_get_ami_push_items_multiple_tasks(requests_mock):
             origin="/fake/path/aws/",
             build=None,
             build_info=None,
+            cloud_info=VMICloudInfo(provider="aws", account="aws-emea"),
             signing_key=None,
             release=AmiRelease(
                 product="SAP",
@@ -427,6 +435,7 @@ def test_get_ami_push_items_multiple_tasks(requests_mock):
             origin="/fake/path/aws/",
             build=None,
             build_info=None,
+            cloud_info=VMICloudInfo(provider="aws", account="aws-na"),
             signing_key=None,
             release=AmiRelease(
                 product="SAP",
@@ -469,6 +478,7 @@ def test_get_ami_push_items_multiple_tasks(requests_mock):
             origin="/fake/path/aws/",
             build=None,
             build_info=None,
+            cloud_info=VMICloudInfo(provider="aws", account="aws-emea"),
             signing_key=None,
             release=AmiRelease(
                 product="SAP",


### PR DESCRIPTION
This commit introduces a new optional property for all VMIPushItems named `VMICloudInformation` which stores the cloud's provider name and account alias into it.

The goal of this change is to be able to parse the patched `clouds.json` with this new property, which was introduced in
https://github.com/release-engineering/pubtools-marketplacesvm/pull/71 , allowing the DeleteTask to have a more reliable way to retrieve the provider/account information.

Refers to SPSTRAT-363