### PR TITLE
Add content reader to decouple NFS file reads [RHELDST-26339]

### DIFF
--- a/src/pushsource/_impl/list_cmd.py
+++ b/src/pushsource/_impl/list_cmd.py
@@ -36,6 +36,10 @@ from pushsource import Source
 
 LOG = logging.getLogger("pushsource-ls")
 
+EXCLUDED_ATTRIBUTES = [
+    "opener",
+]
+
 
 class ItemDumper(yaml.SafeDumper):
     # Custom dumper adding support for any types appearing on pushitems
@@ -77,7 +81,13 @@ def format_python_black(item):
 
 
 def format_yaml(item):
-    data = {type(item).__name__: attr.asdict(item, recurse=True)}
+    data = {
+        type(item).__name__: attr.asdict(
+            item,
+            recurse=True,
+            filter=lambda attribute, _: attribute.name not in EXCLUDED_ATTRIBUTES,
+        )
+    }
     return yaml.dump([data], Dumper=ItemDumper)
 
 

--- a/src/pushsource/_impl/model/comps.py
+++ b/src/pushsource/_impl/model/comps.py
@@ -1,5 +1,6 @@
 from .base import PushItem
 from .. import compat_attr as attr
+from ..utils.openers import open_src_local
 
 
 @attr.s()
@@ -11,4 +12,12 @@ class CompsXmlPushItem(PushItem):
     group definitions) in the format used by yum & dnf.
 
     This library does not verify that the referenced file is valid.
+    """
+
+    opener = attr.ib(type=callable, default=open_src_local, repr=False)
+    """Identical to :attr:`~pushsource.PushItem.opener`.
+
+    This defaults to reading content as file from :attr:`~pushsource.PushItem.src`
+    
+    .. versionadded:: 2.51.0
     """

--- a/src/pushsource/_impl/model/directory.py
+++ b/src/pushsource/_impl/model/directory.py
@@ -1,5 +1,6 @@
 from .base import PushItem
 from .. import compat_attr as attr
+from ..utils.openers import open_src_local
 
 
 @attr.s()
@@ -9,3 +10,11 @@ class DirectoryPushItem(PushItem):
     On a directory push item, the src attribute contains the full path to a directory tree.
     It should generally be interpreted as a request to recursively publish that entire directory
     tree as-is."""
+
+    opener = attr.ib(type=callable, default=open_src_local, repr=False)
+    """Identical to :attr:`~pushsource.PushItem.opener`.
+
+    This defaults to reading content as file from :attr:`~pushsource.PushItem.src`
+    
+    .. versionadded:: 2.51.0
+    """

--- a/src/pushsource/_impl/model/file.py
+++ b/src/pushsource/_impl/model/file.py
@@ -1,6 +1,7 @@
 from .base import PushItem
 from .. import compat_attr as attr
 from .conv import optional_str, convert_maybe
+from ..utils.openers import open_src_local
 
 
 @attr.s()
@@ -52,3 +53,11 @@ class FilePushItem(PushItem):
         # - This check will also filter out NaN.
         if not -99999 <= value <= 99999:
             raise ValueError("display_order must be within range -99999 .. 99999")
+
+    opener = attr.ib(type=callable, default=open_src_local, repr=False)
+    """Identical to :attr:`~pushsource.PushItem.opener`.
+
+    This defaults to reading content as file from :attr:`~pushsource.PushItem.src`
+    
+    .. versionadded:: 2.51.0
+    """

--- a/src/pushsource/_impl/model/modulemd.py
+++ b/src/pushsource/_impl/model/modulemd.py
@@ -1,5 +1,6 @@
 from .base import PushItem
 from .. import compat_attr as attr
+from ..utils.openers import open_src_local
 
 
 @attr.s()
@@ -14,6 +15,14 @@ class ModuleMdPushItem(PushItem):
     modulemd stream.
     """
 
+    opener = attr.ib(type=callable, default=open_src_local, repr=False)
+    """Identical to :attr:`~pushsource.PushItem.opener`.
+
+    This defaults to reading content as file from :attr:`~pushsource.PushItem.src`
+    
+    .. versionadded:: 2.51.0
+    """
+
 
 @attr.s()
 class ModuleMdSourcePushItem(PushItem):
@@ -24,4 +33,12 @@ class ModuleMdSourcePushItem(PushItem):
 
     This library does not verify that the referenced file is a valid
     modulemd source document.
+    """
+
+    opener = attr.ib(type=callable, default=open_src_local, repr=False)
+    """Identical to :attr:`~pushsource.PushItem.opener`.
+
+    This defaults to reading content as file from :attr:`~pushsource.PushItem.src`
+    
+    .. versionadded:: 2.51.0
     """

--- a/src/pushsource/_impl/model/productid.py
+++ b/src/pushsource/_impl/model/productid.py
@@ -7,6 +7,7 @@ from pyasn1.codec.der import decoder
 from .base import PushItem
 from .conv import convert_maybe, sloppylist
 from .. import compat_attr as attr
+from ..utils.openers import open_src_local
 
 
 # Red Hat OID namespace is "1.3.6.1.4.1.2312.9",
@@ -114,3 +115,11 @@ class ProductIdPushItem(PushItem):
             )
             result.append(product)
         return result
+
+    opener = attr.ib(type=callable, default=open_src_local, repr=False)
+    """Identical to :attr:`~pushsource.PushItem.opener`.
+
+    This defaults to reading content as file from :attr:`~pushsource.PushItem.src`
+    
+    .. versionadded:: 2.51.0
+    """

--- a/src/pushsource/_impl/model/rpm.py
+++ b/src/pushsource/_impl/model/rpm.py
@@ -1,6 +1,7 @@
 from .base import PushItem
 from .conv import optional_str
 from .. import compat_attr as attr
+from ..utils.openers import open_src_local
 
 
 @attr.s()
@@ -31,4 +32,12 @@ class RpmPushItem(PushItem):
 
     .. _ghc-8.4-820200708061905.9edba152: https://koji.fedoraproject.org/koji/buildinfo?buildID=1767200
     .. _ghc-8.4.4-74.module_el8+12161+cf1bd7f2: https://koji.fedoraproject.org/koji/buildinfo?buildID=1767130
+    """
+
+    opener = attr.ib(type=callable, default=open_src_local, repr=False)
+    """Identical to :attr:`~pushsource.PushItem.opener`.
+
+    This defaults to reading content as file from :attr:`~pushsource.PushItem.src`
+    
+    .. versionadded:: 2.51.0
     """

--- a/src/pushsource/_impl/reader.py
+++ b/src/pushsource/_impl/reader.py
@@ -1,0 +1,19 @@
+from io import BufferedReader, SEEK_SET, UnsupportedOperation
+
+
+class PushItemReader(BufferedReader):
+    # Internal class to ensure that the file-like content object returned by
+    # the push items are read-only and non-seekable with a name attribute.
+    def __init__(self, raw, name, **kwargs):
+        super(PushItemReader, self).__init__(raw, **kwargs)
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    def seekable(self):
+        return False
+
+    def seek(self, offset, whence=SEEK_SET):
+        raise UnsupportedOperation(f"Seek unsupported while reading {self.name}")

--- a/src/pushsource/_impl/utils/openers.py
+++ b/src/pushsource/_impl/utils/openers.py
@@ -1,0 +1,5 @@
+def open_src_local(item):
+    # default opener for the push items
+    # assumes that the item's 'src' points to the
+    # locally-accessible file
+    return open(item.src, "rb")

--- a/tests/baseline/cases/direct-cgw.yml
+++ b/tests/baseline/cases/direct-cgw.yml
@@ -15,6 +15,7 @@ items:
     - dest
     md5sum: null
     name: cgw.yaml
+    opener: null
     origin: direct
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/direct-comps.yml
+++ b/tests/baseline/cases/direct-comps.yml
@@ -14,6 +14,7 @@ items:
     dest: []
     md5sum: null
     name: mycomps.xml
+    opener: open_src_local
     origin: direct
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/direct-dir.yml
+++ b/tests/baseline/cases/direct-dir.yml
@@ -15,6 +15,7 @@ items:
     - /destdir
     md5sum: null
     name: srcdir
+    opener: open_src_local
     origin: direct
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/direct-file.yml
+++ b/tests/baseline/cases/direct-file.yml
@@ -18,6 +18,7 @@ items:
     display_order: null
     md5sum: null
     name: custom-filename
+    opener: open_src_local
     origin: direct
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/direct-modulemd-src.yml
+++ b/tests/baseline/cases/direct-modulemd-src.yml
@@ -14,6 +14,7 @@ items:
     dest: []
     md5sum: null
     name: modules.src.txt
+    opener: open_src_local
     origin: direct
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/direct-modulemd.yml
+++ b/tests/baseline/cases/direct-modulemd.yml
@@ -14,6 +14,7 @@ items:
     dest: []
     md5sum: null
     name: my-best-module
+    opener: open_src_local
     origin: direct
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/direct-productid.yml
+++ b/tests/baseline/cases/direct-productid.yml
@@ -17,6 +17,7 @@ items:
     - repo3
     md5sum: null
     name: some-cert
+    opener: open_src_local
     origin: direct
     products:
     - architecture:

--- a/tests/baseline/cases/direct-rpm.yml
+++ b/tests/baseline/cases/direct-rpm.yml
@@ -15,6 +15,7 @@ items:
     md5sum: null
     module_build: null
     name: test.rpm
+    opener: open_src_local
     origin: custom-origin
     sha256sum: null
     signing_key: A1B2C3

--- a/tests/baseline/cases/errata-containers-legacy-repos.yml
+++ b/tests/baseline/cases/errata-containers-legacy-repos.yml
@@ -28,6 +28,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -79,6 +80,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -130,6 +132,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -181,6 +184,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -232,6 +236,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -283,6 +288,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -335,6 +341,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -386,6 +393,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -437,6 +445,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -488,6 +497,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -539,6 +549,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -590,6 +601,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -641,6 +653,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -692,6 +705,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -743,6 +757,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -794,6 +809,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -846,6 +862,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -897,6 +914,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -948,6 +966,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -999,6 +1018,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1050,6 +1070,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1101,6 +1122,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1152,6 +1174,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1203,6 +1226,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1254,6 +1278,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1305,6 +1330,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1356,6 +1382,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1407,6 +1434,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1459,6 +1487,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1510,6 +1539,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1561,6 +1591,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1612,6 +1643,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1663,6 +1695,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1714,6 +1747,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1766,6 +1800,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1817,6 +1852,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1897,6 +1933,7 @@ items:
     issued: 2020-07-08 22:16:09 UTC
     md5sum: null
     name: RHBA-2020:2807
+    opener: null
     origin: null
     pkglist: []
     pushcount: '3'
@@ -1971,6 +2008,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2018,6 +2056,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2065,6 +2104,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2112,6 +2152,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2146,6 +2187,7 @@ items:
     dest: []
     md5sum: null
     name: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2176,6 +2218,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2223,6 +2266,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2270,6 +2314,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2317,6 +2362,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2351,6 +2397,7 @@ items:
     dest: []
     md5sum: null
     name: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2381,6 +2428,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2428,6 +2476,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2475,6 +2524,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2522,6 +2572,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2556,6 +2607,7 @@ items:
     dest: []
     md5sum: null
     name: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2586,6 +2638,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2633,6 +2686,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2680,6 +2734,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2727,6 +2782,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2761,6 +2817,7 @@ items:
     dest: []
     md5sum: null
     name: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2791,6 +2848,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2838,6 +2896,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2885,6 +2944,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2932,6 +2992,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2966,6 +3027,7 @@ items:
     dest: []
     md5sum: null
     name: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2996,6 +3058,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3043,6 +3106,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3090,6 +3154,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3137,6 +3202,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3171,6 +3237,7 @@ items:
     dest: []
     md5sum: null
     name: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -3201,6 +3268,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3248,6 +3316,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3295,6 +3364,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3342,6 +3412,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3376,6 +3447,7 @@ items:
     dest: []
     md5sum: null
     name: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -3406,6 +3478,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3453,6 +3526,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3500,6 +3574,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3547,6 +3622,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3581,6 +3657,7 @@ items:
     dest: []
     md5sum: null
     name: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null

--- a/tests/baseline/cases/errata-containers.yml
+++ b/tests/baseline/cases/errata-containers.yml
@@ -28,6 +28,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:05db9dc3ed76f6cf993f0dd35aa51892a38ba51afdf8ed564a236d53d8375a47.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -79,6 +80,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -130,6 +132,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:115387bd7efba2bdb7ee9f0d4fff88f03c1579859c6230cc67bb5c0b31263ba8.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -181,6 +184,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -232,6 +236,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -283,6 +288,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -335,6 +341,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -386,6 +393,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -437,6 +445,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -488,6 +497,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -539,6 +549,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -590,6 +601,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -641,6 +653,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -692,6 +705,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -743,6 +757,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -794,6 +809,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -846,6 +862,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -897,6 +914,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -948,6 +966,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:bbb14d32c62f4303e16256fd8d3f5123e789da1b2aee81e82b316908fcf9e28b.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -999,6 +1018,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1050,6 +1070,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:be2056f3f63c8391fe60f5a6043c4d1a718bf52fb49fba39c18628b930661baf.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1101,6 +1122,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1152,6 +1174,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1203,6 +1226,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1254,6 +1278,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1305,6 +1330,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1356,6 +1382,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1407,6 +1434,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1459,6 +1487,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1510,6 +1539,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1561,6 +1591,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1612,6 +1643,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1663,6 +1695,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1714,6 +1747,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1766,6 +1800,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1817,6 +1852,7 @@ items:
       com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
     md5sum: null
     name: docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
+    opener: null
     origin: RHBA-2020:2807
     product_name: Red Hat OpenShift Enterprise
     pull_info:
@@ -1897,6 +1933,7 @@ items:
     issued: 2020-07-08 22:16:09 UTC
     md5sum: null
     name: RHBA-2020:2807
+    opener: null
     origin: null
     pkglist: []
     pushcount: '3'
@@ -1971,6 +2008,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:da1d6900c5f541a18295f66312cb8d0999aab6f425a6bbccdd2fd8bcc72300f1.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2018,6 +2056,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e3f74d3b725d2f6f32d652e4c13854e789e283f8673514b0749f796f5367b46f.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2065,6 +2104,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:2c6e2f845291914c4e9ecf2eff31be45379ba3ad8b42fc133df83219d5c6039d.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2112,6 +2152,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e859f5623bde399f46690b91c5be657aaa1fe98943930e6f6a2848199b6a7b03.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2146,6 +2187,7 @@ items:
     dest: []
     md5sum: null
     name: cluster-logging-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2176,6 +2218,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:f49167b645594fec8171bcffa2ba4c652d2fc6a8a39c8d04c8ac9891833429f6.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2223,6 +2266,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:bc6da6c39d2778a070d09c619927d0fc3890b71080b00c89412e2b55859a040a.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2270,6 +2314,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e395580a86026948eeed45d1ac406a5b3ce355aa0f48de23877ddfb61ca2cf62.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2317,6 +2362,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:d9ca1606333cc9badec48c4fe4895ae19b5ea5b29bb9601e17c7fb79cdd7ea19.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2351,6 +2397,7 @@ items:
     dest: []
     md5sum: null
     name: cluster-nfd-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2381,6 +2428,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:21d47ff01a369d38611df7d513636bd1eaf2787b4424620fa2297093cb7efd87.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2428,6 +2476,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:6f1e0eb900873d800ec3cfc2c07405067679a935b4986e4dddb53037b78276ed.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2475,6 +2524,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:30c942b23500e7d289671ebfa3f5a840a264620bae2c470fcf6f8b2928f066a0.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2522,6 +2572,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:088c14ddcc989815bb38871fe9e0d3387a762c07a2ca23c9fd375ce42e3e53d6.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2556,6 +2607,7 @@ items:
     dest: []
     md5sum: null
     name: elasticsearch-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2586,6 +2638,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:cc201958cbe1eb7f5282c1df2a1d1baf8f7c0ab0d2783a4cb1d4e1aa88ba6543.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2633,6 +2686,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:497acb6ab8035229e662283a4fed020835ff92831ea0300864ae428874181df8.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2680,6 +2734,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:f01dbc59e3d0c08d9df77852cefcd8f8bc4bd66587cd4afbb399853f38b1085c.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2727,6 +2782,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e86f4ab4555a4acf8dcb6f2349b0a8fd8ed16ac9d3df039c50014b36a7a8b181.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2761,6 +2817,7 @@ items:
     dest: []
     md5sum: null
     name: local-storage-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2791,6 +2848,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:24d0f51bd83a274c584a2aef98e6e504e71399c1cd536c3891a70d3ae3627278.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2838,6 +2896,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e507f8aae9b8b13573e39ffded36375daeed686c0953bc1fd6af601713e0d191.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2885,6 +2944,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:f5b69a6fd18b7c6189824dff60f834ee4405b338579f5e37b7e6316f70460ac8.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2932,6 +2992,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:ac3482bc646895faea206cae1af0ab7fbe5a5e8e323f7fdcd01bda47e33d569f.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -2966,6 +3027,7 @@ items:
     dest: []
     md5sum: null
     name: openshift-enterprise-ansible-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -2996,6 +3058,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:8aff8f23622971d84fea7892062731af8c8611b887cbad8a3ef488055fa4ed04.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3043,6 +3106,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:39fa57800aaa583cce939c5d1f6b8b9cc47fd903b1f2e8776d5b1d7cbf9dee4b.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3090,6 +3154,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:f40245eeba63f6f1cd0b1b59a683a6ca6a5051194f55386e26e5fdd234433bb4.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3137,6 +3202,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:9661ac2d9c97b5cffdf6bc41f1bc98020890a63918416d32e3fdead286229342.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3171,6 +3237,7 @@ items:
     dest: []
     md5sum: null
     name: openshift-enterprise-template-service-broker-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -3201,6 +3268,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:176277a797bafa67823741efa319c2844758b2d5a4cb796b75a8b67580b54d56.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3248,6 +3316,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:b248b0d65ac239f8cacbe71d892ea7d829db0171abb922f1caf6e888fb8c1bcc.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3295,6 +3364,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:1dd3df4e8e532526b10155839caddef35cc731e586de169c60af9d72234e6640.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3342,6 +3412,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:e437e702740efe93906c9b2e9e2a6e53863ccaa2aa49dfc6fa4a9047d37f0d2b.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3376,6 +3447,7 @@ items:
     dest: []
     md5sum: null
     name: ose-metering-ansible-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null
@@ -3406,6 +3478,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:fe0511050968b1355e91c143eea7937e6b96e50e41f1c07d09af3c344c53df65.aarch64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3453,6 +3526,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:d55b1d209c064dc8fd17952f2b0fdaccedf3905bce5701910302a2cd08b3a2a7.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3500,6 +3574,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:28b65974f88b0bc2c39b1e8f4aba6b5554f72b1650f69e63aeb5449bb48f58ee.s390x.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3547,6 +3622,7 @@ items:
         com.redhat.license_terms: https://www.redhat.com/en/about/red-hat-end-user-license-agreements
       md5sum: null
       name: docker-image-sha256:96b0fc687f7eac12b7773dfc568cab1f39a005378108a057408cfb184c7b25c5.ppc64le.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -3581,6 +3657,7 @@ items:
     dest: []
     md5sum: null
     name: ose-ptp-operator-metadata-container-v4.3.28.202006290519.p0.prod-1/operator_manifests.zip
+    opener: null
     origin: RHBA-2020:2807
     related_images: []
     sha256sum: null

--- a/tests/baseline/cases/koji-operator-container.yml
+++ b/tests/baseline/cases/koji-operator-container.yml
@@ -32,6 +32,7 @@ items:
       operators.operatorframework.io.bundle.package.v1: security-profiles-operator
     md5sum: null
     name: docker-image-sha256:eb6788bfdcb4c1743176a99440754e925725664e037180ab974fd64a238fae29.x86_64.tar.gz
+    opener: null
     origin: null
     product_name: null
     pull_info:
@@ -94,6 +95,7 @@ items:
         operators.operatorframework.io.bundle.package.v1: security-profiles-operator
       md5sum: null
       name: docker-image-sha256:eb6788bfdcb4c1743176a99440754e925725664e037180ab974fd64a238fae29.x86_64.tar.gz
+      opener: null
       origin: null
       product_name: null
       pull_info:
@@ -128,6 +130,7 @@ items:
     dest: []
     md5sum: null
     name: security-profiles-operator-bundle-container-0.5.2-2/operator_manifests.zip
+    opener: null
     origin: null
     related_images:
     - registry.redhat.io/compliance/openshift-security-profiles-rhel8-operator@sha256:04bd4e8dc14f2bf6fb9bfceb4c0987c059190af6fd4f4c7ca2fda2b8760315ee

--- a/tests/baseline/cases/koji-source-container.yml
+++ b/tests/baseline/cases/koji-source-container.yml
@@ -21,6 +21,7 @@ items:
     labels: {}
     md5sum: null
     name: docker-image-sha256:bfe520f7c81aeb3eaeb732ab93dd76b279b6a01a16a27f1ec34d5b2fcefbb363.x86_64.tar.gz
+    opener: null
     origin: null
     product_name: null
     pull_info:

--- a/tests/baseline/cases/staged-simple-ami-bc.yml
+++ b/tests/baseline/cases/staged-simple-ami-bc.yml
@@ -29,6 +29,7 @@ items:
     marketplace_title_template: null
     md5sum: null
     name: fake-image.raw
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_ami_with_bc
     public_image: true
     recommended_instance_type: t2.micro

--- a/tests/baseline/cases/staged-simple-ami-bootmode.yml
+++ b/tests/baseline/cases/staged-simple-ami-bootmode.yml
@@ -25,6 +25,7 @@ items:
     marketplace_title_template: null
     md5sum: null
     name: fake-image.raw
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_ami_with_bootmode
     public_image: true
     recommended_instance_type: null

--- a/tests/baseline/cases/staged-simple-ami-uefi.yml
+++ b/tests/baseline/cases/staged-simple-ami-uefi.yml
@@ -25,6 +25,7 @@ items:
     marketplace_title_template: null
     md5sum: null
     name: fake-image.raw
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_ami_with_uefi
     public_image: true
     recommended_instance_type: null

--- a/tests/baseline/cases/staged-simple-ami.yml
+++ b/tests/baseline/cases/staged-simple-ami.yml
@@ -25,6 +25,7 @@ items:
     marketplace_title_template: null
     md5sum: null
     name: fake-image.raw
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_ami
     public_image: true
     recommended_instance_type: null

--- a/tests/baseline/cases/staged-simple-cgw.yml
+++ b/tests/baseline/cases/staged-simple-cgw.yml
@@ -15,6 +15,7 @@ items:
     - dest
     md5sum: null
     name: cgw.yml
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_cgw
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/staged-simple-cloud.yml
+++ b/tests/baseline/cases/staged-simple-cloud.yml
@@ -29,6 +29,7 @@ items:
     marketplace_title_template: null
     md5sum: null
     name: something1.raw.xz
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_cloud/starmap/CLOUD_IMAGES/build2
     public_image: null
     recommended_instance_type: null
@@ -80,6 +81,7 @@ items:
     marketplace_title_template: null
     md5sum: null
     name: something2.raw.xz
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_cloud/starmap/CLOUD_IMAGES/build2
     public_image: null
     recommended_instance_type: null
@@ -131,6 +133,7 @@ items:
     marketplace_title_template: null
     md5sum: null
     name: something1.raw.xz
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_cloud/starmap/CLOUD_IMAGES/build3
     public_image: null
     recommended_instance_type: null
@@ -180,6 +183,7 @@ items:
     marketplace_title_template: null
     md5sum: null
     name: something1.raw.xz
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_cloud/starmap/CLOUD_IMAGES/build1
     recommended_sizes: []
     release:
@@ -218,6 +222,7 @@ items:
     marketplace_title_template: null
     md5sum: null
     name: something2.raw.xz
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_cloud/starmap/CLOUD_IMAGES/build1
     recommended_sizes: []
     release:

--- a/tests/baseline/cases/staged-simple-comps.yml
+++ b/tests/baseline/cases/staged-simple-comps.yml
@@ -15,6 +15,7 @@ items:
     - dest1
     md5sum: null
     name: rawhide-everything.xml
+    opener: open_src_local
     origin: {{ src_dir }}/tests/staged/data/simple_comps
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/staged-simple-directories.yml
+++ b/tests/baseline/cases/staged-simple-directories.yml
@@ -15,6 +15,7 @@ items:
     - dest1
     md5sum: null
     name: dest1
+    opener: open_src_local
     origin: null
     sha256sum: null
     signing_key: null
@@ -27,6 +28,7 @@ items:
     - dest2
     md5sum: null
     name: dest2
+    opener: open_src_local
     origin: null
     sha256sum: null
     signing_key: null
@@ -39,6 +41,7 @@ items:
     - origin
     md5sum: null
     name: origin
+    opener: open_src_local
     origin: null
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/staged-simple-errata.yml
+++ b/tests/baseline/cases/staged-simple-errata.yml
@@ -33,6 +33,7 @@ items:
     issued: 2020-02-17 09:14:49 UTC
     md5sum: null
     name: RHBA-2020:0518
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_errata
     pkglist: []
     pushcount: '1'
@@ -155,6 +156,7 @@ items:
     issued: 2020-02-13 19:00:11 UTC
     md5sum: null
     name: RHSA-2020:0509
+    opener: null
     origin: {{ src_dir }}/tests/staged/data/simple_errata
     pkglist:
     - module: null

--- a/tests/baseline/cases/staged-simple-files.yml
+++ b/tests/baseline/cases/staged-simple-files.yml
@@ -17,6 +17,7 @@ items:
     display_order: 1.5
     md5sum: null
     name: test.txt
+    opener: open_src_local
     origin: {{ src_dir }}/tests/staged/data/simple_files
     sha256sum: d8301c5f72f16455dbc300f3d1bef8972424255caad103cc6c7ba7dc92d90ca8
     signing_key: null
@@ -32,6 +33,7 @@ items:
     display_order: 3.0
     md5sum: null
     name: some-file.txt
+    opener: open_src_local
     origin: {{ src_dir }}/tests/staged/data/simple_files
     sha256sum: 315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3
     signing_key: null
@@ -47,6 +49,7 @@ items:
     display_order: null
     md5sum: null
     name: some-iso
+    opener: open_src_local
     origin: {{ src_dir }}/tests/staged/data/simple_files
     sha256sum: db68c8a70f8383de71c107dca5fcfe53b1132186d1a6681d9ee3f4eea724fabb
     signing_key: null

--- a/tests/baseline/cases/staged-simple-modulemd.yml
+++ b/tests/baseline/cases/staged-simple-modulemd.yml
@@ -15,6 +15,7 @@ items:
     - dest1
     md5sum: null
     name: some-modules.yaml
+    opener: open_src_local
     origin: {{ src_dir }}/tests/staged/data/simple_modulemd
     sha256sum: null
     signing_key: null

--- a/tests/baseline/cases/staged-simple-productid.yml
+++ b/tests/baseline/cases/staged-simple-productid.yml
@@ -15,6 +15,7 @@ items:
     - dest1
     md5sum: null
     name: some-cert
+    opener: open_src_local
     origin: {{ src_dir }}/tests/staged/data/simple_productid
     products:
     - architecture:

--- a/tests/baseline/test_baseline.py
+++ b/tests/baseline/test_baseline.py
@@ -31,13 +31,20 @@ SRC_DIR = os.path.abspath(os.path.join(THIS_DIR, "../.."))
 DATA_DIR = os.path.abspath(os.path.join(THIS_DIR, "../.."))
 
 
+def _callable_to_str(value):
+    if not callable(value):
+        return value
+
+    return getattr(value, "__name__", repr(value))
+
+
 def asdict(value):
     # modern case must use a value_serializer to convert frozendict into a
     # serializable type.
     ret = attr.asdict(
         value,
         recurse=True,
-        value_serializer=lambda _self, _field, value: unfreeze(value),
+        value_serializer=lambda _self, _field, value: _callable_to_str(unfreeze(value)),
     )
     # yaml dump can't handle enums, so export their value instead.
     for k, v in ret.items():

--- a/tests/model/data/test_file.txt
+++ b/tests/model/data/test_file.txt
@@ -1,0 +1,1 @@
+test content

--- a/tests/model/test_push_item_content.py
+++ b/tests/model/test_push_item_content.py
@@ -1,0 +1,45 @@
+import os
+from pytest import raises
+
+from io import UnsupportedOperation
+
+from pushsource import PushItem
+from pushsource._impl.utils.openers import open_src_local
+
+ITEM_SRC = os.path.join(os.path.dirname(__file__), "data/test_file.txt")
+
+
+def test_push_item_content():
+    """Read pushitem content from the source"""
+    item = PushItem(name="test", src=ITEM_SRC, opener=open_src_local)
+
+    assert item.content().name == ITEM_SRC
+    assert item.content().read().decode("utf-8") == "test content\n"
+    # content file object should not seekable or wriateble
+    assert item.content().seekable() == False
+    assert item.content().writable() == False
+
+
+def test_push_item_seek_fail():
+    """Fail when trying to seek content"""
+    with raises(UnsupportedOperation) as exc_info:
+        item = PushItem(name="test", src=ITEM_SRC, opener=open_src_local)
+        item.content().seek(0)
+
+    assert "Seek unsupported" in str(exc_info.value)
+
+
+def test_push_item_content_without_opener():
+    """No content is returned without an opener"""
+    item = PushItem(name="test", src=ITEM_SRC)
+
+    assert item.content() == None
+
+
+def test_push_item_content_context_mgr():
+    """Read pushitem content using its context manager"""
+    item = PushItem(name="test", src=ITEM_SRC, opener=open_src_local)
+
+    with item.content() as f:
+        assert f.name == ITEM_SRC
+        assert f.read().decode("utf-8") == "test content\n"

--- a/tests/staged/test_staged_simple_rpm.py
+++ b/tests/staged/test_staged_simple_rpm.py
@@ -40,6 +40,13 @@ def test_staged_simple_rpm(caplog):
             signing_key=None,
         ),
     ]
+    # RPM content is read from the source in the push items
+    assert files[0].content().name == os.path.join(
+        staged_dir, "dest1/RPMS/walrus-5.21-1.noarch.rpm"
+    )
+    assert files[1].content().name == os.path.join(
+        staged_dir, "dest1/SRPMS/test-srpm01-1.0-1.src.rpm"
+    )
     # It should also warn about this
     nonrpm_path = os.path.join(staged_dir, "dest1/RPMS/not-an-rpm.txt")
     msg = "Unexpected non-RPM %s (ignored)" % nonrpm_path


### PR DESCRIPTION
The API to read content of the push items strongly depends on their presence as file on NFS or locally-mounted filesystem. However, with advent of new push item sources, it likely that the push items might not be stored as a file or be locally available.

Hence, add a new content reader interface that will be implemented by content readers based on the source or content type. The readers can then be used by specific push item types to get their bits from the respective source.

Here, the File content reader implements the interface and is used by default for all push items. This reader reads the bits from the path provided as push item source and returns a file-like object as push item content attribute.