### PR TITLE
Get attr module version without importlib [RHELDST-32151]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+artifacts/
 
 # Translations
 *.mo

--- a/src/pushsource/_impl/compat_attr.py
+++ b/src/pushsource/_impl/compat_attr.py
@@ -1,19 +1,8 @@
 import attr
 
-# importlib.metadata is available for py3.8 and higher
-# previous versions get it from importlib_metadata installed
-# from importlib-metadata
-try:
-    from importlib.metadata import version
-except ImportError:  # pragma: no cover
-    from importlib_metadata import version
-
-
 # Wrappers for attr module to deal with some incompatibilities between versions
 
-
-ATTR_VERSION = tuple(int(x) for x in (version("attrs")).split(".")[0:2])
-
+ATTR_VERSION = tuple(int(x) for x in attr.__version__.split(".")[0:2])
 
 def s():
     kwargs = {"frozen": True, "slots": True}

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -20,6 +20,5 @@ pyhamcrest
 sphinx
 alabaster
 pidiff
-importlib-resources
 bandit
 pytest-mock

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -464,10 +464,6 @@ importlib-metadata==8.7.0 \
     --hash=sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000 \
     --hash=sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd
     # via sphinx
-importlib-resources==6.5.2 \
-    --hash=sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c \
-    --hash=sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec
-    # via -r test-requirements.in
 iniconfig==2.1.0 \
     --hash=sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7 \
     --hash=sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760
@@ -1009,9 +1005,7 @@ virtualenv-api==2.1.18 \
 zipp==3.21.0 \
     --hash=sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4 \
     --hash=sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931
-    # via
-    #   importlib-metadata
-    #   importlib-resources
+    # via importlib-metadata
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes and the requirement is not

--- a/tests/test_compat_attr.py
+++ b/tests/test_compat_attr.py
@@ -1,0 +1,17 @@
+from pushsource._impl import compat_attr
+
+from mock import patch
+
+
+@patch("attr.s")
+def test_attrs(attr_s, monkeypatch):
+    monkeypatch.setattr(compat_attr, "ATTR_VERSION", (17, 4))
+    compat_attr.s()
+    attr_s.assert_called_once_with(frozen=True, slots=True)
+
+
+@patch("attr.s")
+def test_attrs_18_2(attr_s, monkeypatch):
+    monkeypatch.setattr(compat_attr, "ATTR_VERSION", (18, 2))
+    compat_attr.s()
+    attr_s.assert_called_once_with(frozen=True, slots=True, kw_only=True)


### PR DESCRIPTION
For python versions older than 3.8, importlib_metadata module needs to be installed separately, however no such RPM package is available for RHEL 8. The whole ordeal of getting the version of attr module currently installed can be done without importing importlib.

This commit also updates .gitignore to ignore artifacts generated during local tox runs.