### PR TITLE
VMIPushItem: Use converter for boot_mode

### DIFF
--- a/src/pushsource/_impl/model/vms.py
+++ b/src/pushsource/_impl/model/vms.py
@@ -4,7 +4,14 @@ import enum
 from .base import PushItem
 from .. import compat_attr as attr
 from attr import asdict
-from .conv import datestr, instance_of_str, instance_of, optional_str, optional, in_
+from .conv import (
+    convert_maybe,
+    datestr,
+    instance_of_str,
+    instance_of,
+    optional_str,
+    optional,
+)
 
 
 class BootMode(enum.Enum):
@@ -113,7 +120,7 @@ class VMIPushItem(PushItem):
     description = attr.ib(type=str, default=None, validator=instance_of_str)
     """A brief human-readable description of the image."""
 
-    boot_mode = attr.ib(type=BootMode, default=None, validator=optional(in_(BootMode)))
+    boot_mode = attr.ib(type=BootMode, default=None, converter=convert_maybe(BootMode))
     """Boot mode supported by the image (if known): uefi, legacy, or hybrid (uefi + legacy)."""
 
     cloud_info = attr.ib(

--- a/tests/model/test_vmi.py
+++ b/tests/model/test_vmi.py
@@ -1,6 +1,7 @@
+import pytest
 from pytest import raises
 
-from pushsource import VMIRelease, VMIPushItem
+from pushsource import BootMode, VMIRelease, VMIPushItem
 
 
 def test_invalidate_datestr():
@@ -42,3 +43,38 @@ def test_marketplace_title():
         name="myname",
     )
     assert pi.marketplace_title == ""
+
+
+@pytest.mark.parametrize("boot_mode", [None, "hybrid", "uefi", "legacy"])
+def test_bootmode_converter_success(boot_mode):
+    """Ensure the BootMode converter works when valid data is given."""
+
+    release = VMIRelease(
+        product="myprod", arch="x86_64", version="7.0", respin=1, date="20240101"
+    )
+
+    pi = VMIPushItem(
+        description="mydescription", name="myname", release=release, boot_mode=boot_mode
+    )
+
+    if boot_mode:
+        assert pi.boot_mode == BootMode(boot_mode)
+    else:
+        assert not pi.boot_mode
+
+
+@pytest.mark.parametrize("boot_mode", ["foo", "bar", 12])
+def test_bootmode_converter_invalid(boot_mode):
+    """Ensure the BootMode converter fails on invalid data."""
+
+    release = VMIRelease(
+        product="myprod", arch="x86_64", version="7.0", respin=1, date="20240101"
+    )
+
+    with raises(ValueError):
+        VMIPushItem(
+            description="mydescription",
+            name="myname",
+            release=release,
+            boot_mode=boot_mode,
+        )


### PR DESCRIPTION
This commit changes the `VMIPushItem` class to use a converter in the attribute `boot_mode` which is capable of properly converting it to the `BootMode` enum whenever possible.

It fixes issues downstream where the information is given as a string instead of the Enum.

Refers to SPSTRAT-600