### PR TITLE
bugfix(SPSTRAT-601): VHDPushItem model _from_data

### DIFF
--- a/src/pushsource/_impl/model/azure.py
+++ b/src/pushsource/_impl/model/azure.py
@@ -84,7 +84,7 @@ class VHDPushItem(VMIPushItem):
             "description": data["description"],
             "generation": data.get("generation") or None,
             "sku_id": data.get("sku_id") or None,
-            "support_legacy": data.get("support_legacy") or None,
+            "support_legacy": data.get("support_legacy") or False,
             "release": VMIRelease._from_data(data.get("release", {})),
             "legacy_sku_id": data.get("legacy_sku_id") or None,
             "disk_version": data.get("disk_version") or None,

--- a/tests/model/test_vhd.py
+++ b/tests/model/test_vhd.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pytest import raises
+from pytest import mark, raises
 
 from pushsource import VHDPushItem, VMIRelease, AmiRelease
 
@@ -34,6 +34,30 @@ def test_invalid_legacy_sku():
     assert (
         'The attribute "legacy_sku_id" must only be set when "support_legacy" is True.'
     ) in str(exc_info.value)
+
+
+@mark.parametrize("value", [True, False, None])
+def test_support_legacy(value):
+    """Ensure ``support_legacy`` works for all expected inputs."""
+    v = VHDPushItem._from_data(
+        {
+            "name": "test",
+            "release": {
+                "product": "TEST",
+                "date": "20250730",
+                "arch": "x86_64",
+                "respin": 0,
+            },
+            "description": "test",
+            "disk_version": "1.0.0",
+            "sas_uri": "foo.com/bar",
+            "support_legacy": value,
+        }
+    )
+    if value:
+        assert v.support_legacy == value
+    else:
+        assert v.support_legacy == False
 
 
 def test_vmi_release():

--- a/tests/pub/data/3776845/clouds.json
+++ b/tests/pub/data/3776845/clouds.json
@@ -1,0 +1,75 @@
+[
+  {
+    "boot_mode": null,
+    "build": "test-prd-azure-9.6-20250730.3",
+    "build_info": {
+      "id": 3776845,
+      "name": "test-prd-azure",
+      "release": "20250730.3",
+      "version": "9.6"
+    },
+    "cloud_info": {
+      "account": "azure-na",
+      "provider": "azure"
+    },
+    "description": "",
+    "dest": [
+      "test-prd/9_6_prd"
+    ],
+    "generation": "V2",
+    "md5sum": "ac3b1c069d7b3f3ce9e77de83bb4305e",
+    "name": "test-prd-azure-9.6-20250730.3.x86_64.vhd.xz",
+    "origin": "RHBA-2025:123456",
+    "recommended_sizes": [],
+    "release": {
+      "arch": "x86_64",
+      "base_product": null,
+      "base_version": null,
+      "date": "20250730",
+      "product": "TEST-PRD",
+      "respin": 0,
+      "type": null,
+      "variant": null,
+      "version": "9.6"
+    },
+    "sas_uri": "https://test.blob.core.windows.net/pubupload/test-prd-azure-9.6-20250730.3.x86_64.vhd?se=2028-08-05T15%3A05%3A37Z&sp=r&sv=2023-08-03&sr=b&sig=fakesig",
+    "src": "/mnt/koji/packages/test-prd-azure/9.6/20250730.3/images/test-prd-azure-9.6-20250730.3.x86_64.vhd.xz",
+    "starmap_query": {
+      "billing_code_config": {},
+      "cloud": "azure",
+      "mappings": {
+        "azure-na": {
+          "destinations": [
+            {
+              "ami_version_template": null,
+              "architecture": "x86_64",
+              "destination": "test-prd/9_6_prd",
+              "id": null,
+              "meta": {
+                "generation": "V2"
+              },
+              "overwrite": false,
+              "provider": null,
+              "restrict_major": null,
+              "restrict_minor": null,
+              "restrict_version": false,
+              "tags": null,
+              "vhd_check_base_sas_only": true
+            }
+          ],
+          "meta": {
+            "generation": "V2"
+          },
+          "provider": null
+        }
+      },
+      "meta": {
+        "generation": "V2"
+      },
+      "name": "test-prd-azure",
+      "workflow": "stratosphere"
+    },
+    "state": "PUSHED",
+    "support_legacy": false
+  }
+]


### PR DESCRIPTION
This commit fixes a bad converter for `support_legacy` on `VHDPushItem` model which was preventing to load its class using `_from_data` whenever the value for `support_legacy` was `False`.

In the previous version the following line would evaluate the truthful to `else` and cause the `or` to define it as `None`, generating an invalid parameter:

```
"support_legacy": data.get("support_legacy") or None,
```

Besides the fix it also includes a new model test to detect this scenario as well as a test on `Pub` source which reproduces this issue in the previous code.

Refers to SPSTRAT-601