### PR TITLE
feat: add a new source type named "coreos"

### DIFF
--- a/docs/sources/coreos.rst
+++ b/docs/sources/coreos.rst
@@ -1,0 +1,31 @@
+Source: coreos
+==============
+
+The ``coreos`` push source allows the loading of content from a JSON file of OpenShift CoreOS installer from GitHub.
+
+Supported content types:
+
+* AMIs
+* VHDs
+
+
+coreos source URLs
+------------------
+
+The base form of an coreos source URL is:
+
+``coreos:github-url?paths=path1[,path2[,...]]``
+
+For example, retrieving the JSON files for the RHEL 9 and RHEL 10 CoreOS installer would look like:
+
+``coreos:https://github.com/openshift/installer/tree/master?paths=data/coreos-rhel-9.json,data/coreos-rhel-10.json``
+
+The provided GitHub URL should be the base URL of the repository,
+and should contain the tag or branch name of the repository.
+
+Python API reference
+--------------------
+
+.. autoclass:: pushsource.CoreOSSource
+   :members:
+   :special-members: __init__

--- a/src/pushsource/_impl/backend/__init__.py
+++ b/src/pushsource/_impl/backend/__init__.py
@@ -5,3 +5,4 @@ from .staged import StagedSource
 from .registry_source import RegistrySource
 from .direct import DirectSource
 from .pub_source import PubSource
+from .coreos_source import CoreOSSource

--- a/src/pushsource/_impl/backend/coreos_source/__init__.py
+++ b/src/pushsource/_impl/backend/coreos_source/__init__.py
@@ -1,0 +1,1 @@
+from .coreos_source import CoreOSSource

--- a/src/pushsource/_impl/backend/coreos_source/coreos_client.py
+++ b/src/pushsource/_impl/backend/coreos_source/coreos_client.py
@@ -1,0 +1,85 @@
+import json
+import logging
+import os
+import re
+import threading
+from urllib.parse import urlparse, urlunparse
+
+
+import requests
+from more_executors import Executors
+
+LOG = logging.getLogger("pushsource.coreos_client")
+
+
+class CoreOSClient(object):
+    def __init__(self, url, threads=4, timeout=60 * 60, **retry_args):
+        self._executor = (
+            Executors.thread_pool(name="pushsource-coreos-client", max_workers=threads)
+            .with_map(self._unpack_response)
+            .with_retry(**retry_args)
+            .with_timeout(timeout)
+            .with_cancel_on_shutdown()
+        )
+        self._url = url
+        self._tls = threading.local()
+
+    def shutdown(self):
+        self._executor.shutdown(True)
+
+    def _unpack_response(self, response):
+        try:
+            response.raise_for_status()
+            out = response.json()
+        except json.JSONDecodeError:
+            # do not treat invalid json as fatal error
+            out = None
+        return out
+
+    @property
+    def _session(self):
+        if not hasattr(self._tls, "session"):
+            LOG.debug(
+                "Creating requests Session for client of CoreOS service: %s", self._url
+            )
+            self._tls.session = requests.Session()
+        return self._tls.session
+
+    def _do_request(self, method, url):
+        return self._session.request(method, url)
+
+    @staticmethod
+    def convert_github_blob_to_raw(url, path):
+        """Convert github.com/.../blob/... to raw.githubusercontent.com URL."""
+        _GITHUB_BLOB_RE = re.compile(
+            r"^https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/(blob|tree)/(?P<ref>[^/]+)(?:/(?P<path>.+))?$"
+        )
+
+        # Strip query params and fragment from the URL
+        full_url = os.path.join(url, path)
+        parsed_url = urlparse(full_url)
+        clean_url = urlunparse(parsed_url._replace(query="", fragment=""))
+
+        m = _GITHUB_BLOB_RE.match(clean_url.rstrip("/"))
+        if not m:
+            return clean_url  # already raw or non-GitHub
+        d = m.groupdict()
+
+        # Use the shorter raw form which handles branches, tags, and commit SHAs
+        # without needing to distinguish between refs/heads or refs/tags
+        raw_url = f"https://raw.githubusercontent.com/{d['owner']}/{d['repo']}/{d['ref']}/{d['path']}"
+        LOG.info("Converted URL %s to %s", parsed_url, raw_url)
+        return raw_url
+
+    def get_json_f(self, path):
+        """Returns Future[dict|list] holding json obj with VMI push items returned from CoreOS installer file.
+
+        Parameters:
+            path (str)
+                Path to the JSON file containing the CoreOS installer information.
+                Eg.: "data/data/coreos/rhcos.json"
+        """
+        url = self.convert_github_blob_to_raw(self._url, path)
+        LOG.info("Fetching VMI push items from CoreOS installer file: %s", url)
+        ft = self._executor.submit(self._do_request, method="GET", url=url)
+        return ft

--- a/src/pushsource/_impl/backend/coreos_source/coreos_source.py
+++ b/src/pushsource/_impl/backend/coreos_source/coreos_source.py
@@ -1,0 +1,151 @@
+from concurrent import futures
+
+from datetime import datetime, timezone
+from more_executors import Executors
+
+from ...source import Source
+from ...helpers import (
+    force_https,
+    as_completed_with_timeout_reset,
+    list_argument,
+    try_int,
+)
+from ...model import AmiPushItem, VHDPushItem, KojiBuildInfo
+from .coreos_client import CoreOSClient
+
+
+class CoreOSSource(Source):
+    """Source for VMI push items loaded from CoreOS installer file (JSON)."""
+
+    def __init__(
+        self,
+        url,
+        paths,
+        threads=4,
+        timeout=60 * 60,
+    ):
+        """Create a new source.
+
+        Parameters:
+            url (str)
+                Base URL of for the GitHub repository containing the CoreOS installer information.
+                It should contain as well the tag or branch name of the repository.
+                Eg.: https://github.com/openshift/installer/tree/master
+            paths (list[str])
+                List of paths to the JSON files containing the CoreOS installer information.
+                Eg.: ["data/data/coreos/rhcos.json", "data/data/coreos/rhcos-rhel-10.json"]
+            threads (int)
+                Number of threads used for concurrent queries to the CoreOS installer file.
+            timeout (int)
+                Number of seconds after which an error is raised, if no progress is
+                made during queries to the CoreOS installer file.
+        """
+        self._executor = Executors.thread_pool(
+            name="pushsource-coreos", max_workers=threads
+        ).with_cancel_on_shutdown()
+        self._url = force_https(url)
+        self._client = CoreOSClient(url=self._url, threads=threads)
+        self._paths = list_argument(paths)
+        self._timeout = timeout
+
+    def _push_items_from_json(self, json_obj):
+        product_stream = json_obj.get("stream") or ""
+        product_metadata = json_obj.get("metadata") or {}
+        # Get the product name and version from the stream
+        name, version = (
+            product_stream.split("-") if product_stream else ("unknown", "unknown")
+        )
+
+        # Get the release date from the metadata
+        release_date = product_metadata.get("last-modified") or ""
+        if release_date:
+            release_date = datetime.strptime(release_date, "%Y-%m-%dT%H:%M:%SZ")
+        else:
+            release_date = datetime.now(timezone.utc)
+        out = []
+        vms_with_custom_meta_data = []
+        architectures = json_obj.get("architectures") or {}
+        for arch, arch_data in architectures.items():
+            images = arch_data.get("images") or {}
+            for cloud_name, image_data in images.items():
+                if cloud_name == "aws":
+                    # For AWS each region has a different AMI
+                    regions = image_data.get("regions") or {}
+                    for region, region_data in regions.items():
+                        vms_with_custom_meta_data.append(
+                            {
+                                "marketplace_name": "aws",
+                                "push_item_class": AmiPushItem,
+                                "architecture": arch,
+                                "release": region_data.get("release"),
+                                "custom_meta_data": {
+                                    "region": region,
+                                    "src": region_data.get("image"),
+                                },
+                            }
+                        )
+            # Azure images are generally in the "rhel-coreos-extensions" section
+            extensions = arch_data.get("rhel-coreos-extensions") or {}
+            for extension, extension_data in extensions.items():
+                if extension == "azure-disk":
+                    vms_with_custom_meta_data.append(
+                        {
+                            "marketplace_name": "azure",
+                            "architecture": arch,
+                            "push_item_class": VHDPushItem,
+                            "release": extension_data.get("release"),
+                            "custom_meta_data": {
+                                "src": extension_data.get("url"),
+                            },
+                        }
+                    )
+
+        for vm_item in vms_with_custom_meta_data:
+            klass = vm_item.get("push_item_class")
+            rel_klass = klass._RELEASE_TYPE
+            vm_release = vm_item.get("release") or ""
+            vm_respin = try_int(vm_release.split("-")[-1]) or 0
+            release = rel_klass(
+                arch=vm_item.get("architecture"),
+                date=release_date,
+                product=name.upper(),
+                version=version,
+                respin=vm_respin,
+            )
+            out.append(
+                klass(
+                    name=name,
+                    description=f"CoreOS image for {name} {version} on {vm_item['marketplace_name']}",
+                    **vm_item["custom_meta_data"],
+                    build_info=KojiBuildInfo(
+                        name=name,
+                        version=version,
+                        release=vm_release,
+                    ),
+                    release=release,
+                    marketplace_name=vm_item["marketplace_name"],
+                )
+            )
+
+        return out
+
+    def __iter__(self):
+        # Get all json files from the paths
+        json_fs = [self._client.get_json_f(path) for path in self._paths]
+
+        # Convert them to lists of push items
+        push_items_fs = []
+        for f in futures.as_completed(json_fs, timeout=self._timeout):
+            push_items_fs.append(
+                self._executor.submit(self._push_items_from_json, f.result())
+            )
+
+        completed_fs = as_completed_with_timeout_reset(
+            push_items_fs, timeout=self._timeout
+        )
+        for f in completed_fs:
+            for pushitem in f.result():
+                yield pushitem
+
+
+Source.register_backend("coreos", CoreOSSource)

--- a/tests/coreos/conftest.py
+++ b/tests/coreos/conftest.py
@@ -1,0 +1,38 @@
+import os
+import json
+from unittest import mock
+
+import pytest
+
+from pushsource._impl.backend.coreos_source.coreos_client import CoreOSClient
+
+
+@pytest.fixture
+def mock_coreos_client():
+    with mock.patch(
+        "pushsource._impl.backend.coreos_source.coreos_client.requests.Session"
+    ):
+        yield CoreOSClient(url="https://github.com/openshift/installer/tree/master")
+
+
+@pytest.fixture
+def coreos_rhel_9_data():
+    filepath = os.path.join(os.path.dirname(__file__), "data", "coreos-rhel-9.json")
+    with open(filepath, "r") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def coreos_rhel_10_data():
+    filepath = os.path.join(os.path.dirname(__file__), "data", "coreos-rhel-10.json")
+    with open(filepath, "r") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def coreos_missing_data():
+    filepath = os.path.join(
+        os.path.dirname(__file__), "data", "coreos-missing-data.json"
+    )
+    with open(filepath, "r") as f:
+        return json.load(f)

--- a/tests/coreos/data/coreos-missing-data.json
+++ b/tests/coreos/data/coreos-missing-data.json
@@ -1,0 +1,21 @@
+{
+    "metadata": {},
+    "architectures": {
+      "aarch64": {
+        "images": {
+          "aws": {
+            "regions": {
+              "af-south-1": {
+                "image": "ami-09b3b126662fe7a18"
+              }
+            }
+          }
+        },
+        "rhel-coreos-extensions": {
+          "azure-disk": {
+            "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260520-0-azure.aarch64.vhd"
+          }
+        }
+      }
+    }
+  }

--- a/tests/coreos/data/coreos-rhel-10.json
+++ b/tests/coreos/data/coreos-rhel-10.json
@@ -1,0 +1,978 @@
+{
+    "stream": "rhcos-4.22",
+    "metadata": {
+      "last-modified": "2026-05-26T02:00:59Z",
+      "generator": "plume cosa2stream 5f75da4"
+    },
+    "architectures": {
+      "aarch64": {
+        "artifacts": {
+          "aws": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "vmdk.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-aws.aarch64.vmdk.gz",
+                  "sha256": "bd32b73bb0825206dfbe2f8a597971d559ffab0146ed152096e697ef5475437e",
+                  "uncompressed-sha256": "68092d6ac97216c4b4119b095cc6b1818c16e8d8bb2342aa61ba6f7a0fcfe613"
+                }
+              }
+            }
+          },
+          "azure": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "vhd.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-azure.aarch64.vhd.gz",
+                  "sha256": "fbe2ee640c04259e07167c0a84a1b624140c9dca6032d02ffcb55378841bd11c",
+                  "uncompressed-sha256": "33005b34dafdcc65ba179620cbc4851f34a99316404bfa8f3bedc98aba75d935"
+                }
+              }
+            }
+          },
+          "gcp": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "tar.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-gcp.aarch64.tar.gz",
+                  "sha256": "773b76ccbbbdeb2f13139ce946cae0de2511b0eba165fb68a5377479df490695"
+                }
+              }
+            }
+          },
+          "metal": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "4k.raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-metal4k.aarch64.raw.gz",
+                  "sha256": "5ba7f2f7b792b18217c3928c36a2a3201df7dc636a6ad2092b91bdacfd4817a4",
+                  "uncompressed-sha256": "6e66e2feae46f52b1191e5fa5ddef0b83e4c2e23c55a0178d776dd6419ecd75a"
+                }
+              },
+              "iso": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-live-iso.aarch64.iso",
+                  "sha256": "f3de8f2a2738bbff8608a04a527b5b9cccaa79004a28e6a8f1d5346d6652bfe1"
+                }
+              },
+              "pxe": {
+                "kernel": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-live-kernel.aarch64",
+                  "sha256": "365986469730ef6cd2317a3a098dd6bb3d128a24d28c028d65f3e538399eaa25"
+                },
+                "initramfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-live-initramfs.aarch64.img",
+                  "sha256": "3cf9b99d778920ff7414a1794ff3eb35caaaedf251c893e46e0b8788cce5ad23"
+                },
+                "rootfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-live-rootfs.aarch64.img",
+                  "sha256": "14fa9211d61be123629d79455954066716299fd3ffbf06f186947c4ed39b9edd"
+                }
+              },
+              "raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-metal.aarch64.raw.gz",
+                  "sha256": "dbad89cb3030e8c6a604096aaea25ecef499c26f99fbe3958e25f350302e2e75",
+                  "uncompressed-sha256": "0788dee3e530657a02fab3cc9cdd6790584646cb1faadb711a658db1430b1eb3"
+                }
+              }
+            }
+          },
+          "nvidiabluefield": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "bfb": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-nvidiabluefield.aarch64.bfb",
+                  "sha256": "ecd65bd9222d9e2d5bdbd5f9e4d6a6e7ec4d6126e9e3140eec4f4a3b9303c9e3"
+                }
+              }
+            }
+          },
+          "openstack": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-openstack.aarch64.qcow2.gz",
+                  "sha256": "6f45b5b6e92d281784e637c84ec50d8fb16a13b625e741380af3877e40a30b71",
+                  "uncompressed-sha256": "4b2864015614b31c109c773cec891809979e55fe3ef805a30bb0748c0c1ddc06"
+                }
+              }
+            }
+          },
+          "qemu": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/aarch64/rhcos-10.2.20260521-0-qemu.aarch64.qcow2.gz",
+                  "sha256": "0689a095bab6701e0b4c3a806d18b3792f901cacde14e9881459a9c0b184e90c",
+                  "uncompressed-sha256": "7036887cc41bf84c78abf9c1bd76d0425932d1c18853b46392660ca61de7c1f0"
+                }
+              }
+            }
+          }
+        },
+        "images": {
+          "aws": {
+            "regions": {
+              "af-south-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-07c2492a6e610eb29"
+              },
+              "ap-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0c081ca051d9066c3"
+              },
+              "ap-east-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-016834812d68d485e"
+              },
+              "ap-northeast-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0a93317cde971c817"
+              },
+              "ap-northeast-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-008d018630379e1eb"
+              },
+              "ap-northeast-3": {
+                "release": "10.2.20260521-0",
+                "image": "ami-016bf4359ca8f9ea2"
+              },
+              "ap-south-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-01c3da87c9088e490"
+              },
+              "ap-south-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-089e3dc824dfc53cc"
+              },
+              "ap-southeast-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-047501898db0e6004"
+              },
+              "ap-southeast-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-00aa2f8c59143b0ae"
+              },
+              "ap-southeast-3": {
+                "release": "10.2.20260521-0",
+                "image": "ami-001bd2512362e7b35"
+              },
+              "ap-southeast-4": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0c3a562ba17fcc7fe"
+              },
+              "ap-southeast-5": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0abc0ee6a009667b2"
+              },
+              "ap-southeast-6": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0c8b6c104987a0fc3"
+              },
+              "ap-southeast-7": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0fbf9de5c1828e872"
+              },
+              "ca-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-06be00da14f45f988"
+              },
+              "ca-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0260b4a668a59a922"
+              },
+              "eu-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-001fdc3025ce50006"
+              },
+              "eu-central-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0443b053f6e845524"
+              },
+              "eu-north-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-06bc091c0435adf6f"
+              },
+              "eu-south-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-02ee91218bdc1bb3a"
+              },
+              "eu-south-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0b8943a7a26627b01"
+              },
+              "eu-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-064942d9b57521cf3"
+              },
+              "eu-west-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0e13b80ab624fc7d3"
+              },
+              "eu-west-3": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0b1bd601d3ecde37d"
+              },
+              "il-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0073de64ca6a1189b"
+              },
+              "mx-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-03bf73795d8dfac51"
+              },
+              "sa-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0f8e239c3eb87df2b"
+              },
+              "us-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-04ec52f48c28d001d"
+              },
+              "us-east-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0469df626c198243e"
+              },
+              "us-gov-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-03557a94deb16be46"
+              },
+              "us-gov-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-06460c1920305cf08"
+              },
+              "us-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0cd45be3140b38916"
+              },
+              "us-west-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-03206cc79683aa1a6"
+              }
+            }
+          },
+          "gcp": {
+            "release": "10.2.20260521-0",
+            "project": "rhcos-cloud",
+            "name": "rhcos-10-2-20260521-0-gcp-aarch64"
+          }
+        },
+        "rhel-coreos-extensions": {
+          "azure-disk": {
+            "release": "10.2.20260521-0",
+            "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260521-0-azure.aarch64.vhd"
+          }
+        }
+      },
+      "ppc64le": {
+        "artifacts": {
+          "metal": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "4k.raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-metal4k.ppc64le.raw.gz",
+                  "sha256": "026a99219cbd059e6a22308379dfff614d8ab078b897dff555a0fcd5c87d9ee7",
+                  "uncompressed-sha256": "7268e36c0758b4d66277fa377da841f4d83dd93f9738ab2b6bb803a155f5d379"
+                }
+              },
+              "iso": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-live-iso.ppc64le.iso",
+                  "sha256": "81590c320baacdaa8e2b2e69881778eeda40da01e83cb76dce72160760f45166"
+                }
+              },
+              "pxe": {
+                "kernel": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-live-kernel.ppc64le",
+                  "sha256": "00d01662a7b9da0e27916100111fe671b79ff3fc1ab50f64e4f0559341e85b3a"
+                },
+                "initramfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-live-initramfs.ppc64le.img",
+                  "sha256": "f3f0f3eeee37d5114b531d30343c8ab439c552bd2a410cfc2031a3b137ba0412"
+                },
+                "rootfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-live-rootfs.ppc64le.img",
+                  "sha256": "1dd81165197a9edfa2299a51f8ad773693d7c9ed0b213a89a81cdb4d21080514"
+                }
+              },
+              "raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-metal.ppc64le.raw.gz",
+                  "sha256": "d53bbc5d729a4df41362eb035800d36195d13bb5bd9fec6985c6dee4a3a61215",
+                  "uncompressed-sha256": "d3e2eb723a3ba28032e5e09bb18ab598e392145b7399e3f5266ceddbf8d8fcc0"
+                }
+              }
+            }
+          },
+          "openstack": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-openstack.ppc64le.qcow2.gz",
+                  "sha256": "8f0aee982883aef04ac1c7594ac8a398a79ba813e3725f5fd0fe89e330b2cfb8",
+                  "uncompressed-sha256": "1bd66edab0cee310420a295ac0a997b1de506547d96a12cd7a1b8fb1d10244e2"
+                }
+              }
+            }
+          },
+          "powervs": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "ova.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-powervs.ppc64le.ova.gz",
+                  "sha256": "94d9592da03672e9722640a5eb783a658380f6bbe7d49c2a8e1b94e9f52d7ece",
+                  "uncompressed-sha256": "c2559c7ac0237dcf600c0dabdf0624c5d3a4697aff4a98a0236a3d9a527cd1b5"
+                }
+              }
+            }
+          },
+          "qemu": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/ppc64le/rhcos-10.2.20260521-0-qemu.ppc64le.qcow2.gz",
+                  "sha256": "c9df8c5caa0b80e3107c5ea988fc08805116c6829652f582f5ea50f9ec98e2d2",
+                  "uncompressed-sha256": "4c507e6bb0592629e41e89e15d6b8f10326fbda0c2e734e94259537874711804"
+                }
+              }
+            }
+          }
+        },
+        "images": {
+          "powervs": {
+            "regions": {
+              "au-syd": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-au-syd",
+                "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              },
+              "br-sao": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-br-sao",
+                "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              },
+              "ca-tor": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-ca-tor",
+                "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              },
+              "eu-de": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-eu-de",
+                "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              },
+              "eu-es": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-eu-es",
+                "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              },
+              "eu-gb": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-eu-gb",
+                "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              },
+              "jp-osa": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-jp-osa",
+                "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              },
+              "jp-tok": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-jp-tok",
+                "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              },
+              "us-east": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-us-east",
+                "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              },
+              "us-south": {
+                "release": "10.2.20260521-0",
+                "object": "rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-us-south",
+                "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-10-2-20260521-0-ppc64le-powervs.ova.gz"
+              }
+            }
+          }
+        }
+      },
+      "s390x": {
+        "artifacts": {
+          "ibmcloud": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-ibmcloud.s390x.qcow2.gz",
+                  "sha256": "be9128478123b1c8f1c6ae9980ad5969ce57ffdad13c9d72463240be96445cca",
+                  "uncompressed-sha256": "ef2531a6fb5b070159148ed0161abac3255079cd302317aceef0f567e0bbbf26"
+                }
+              }
+            }
+          },
+          "kubevirt": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "ociarchive": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-kubevirt.s390x.ociarchive",
+                  "sha256": "e40618141ea6e6c3716fa98debfdb7643018bb60f686e939bbf60d0bd3f11b24"
+                }
+              }
+            }
+          },
+          "metal": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "4k.raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-metal4k.s390x.raw.gz",
+                  "sha256": "afa3cb0d123cbf54860405c59520ed27817f874cd88c3e757d314073af7db820",
+                  "uncompressed-sha256": "53d4ef3b6c6137a9d9a8e856e4e1b261562486fe5de7e1be5cc534bccbc39bd2"
+                }
+              },
+              "iso": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-live-iso.s390x.iso",
+                  "sha256": "50fe6c0ed31ad4c3e82ae0a38ff8cdcfb0364c8bfcfd5d43647408a47c4cbdc8"
+                }
+              },
+              "pxe": {
+                "kernel": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-live-kernel.s390x",
+                  "sha256": "692867f01e6be50813a1f00a28155e849f767668898245cd14a72178b5b2b370"
+                },
+                "initramfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-live-initramfs.s390x.img",
+                  "sha256": "9c6435d31ff5a07b1cc207374658f6d84dac4e00663fc91cf22de61a9ae848fd"
+                },
+                "rootfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-live-rootfs.s390x.img",
+                  "sha256": "3371e495ca82ff82cafeb93021e6f2895682bbbd7f89759771f7a5faace94118"
+                }
+              },
+              "raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-metal.s390x.raw.gz",
+                  "sha256": "99d5db5944a4010dbe4d49177f6a7661a7774c1dd57a0259023bb7c594579158",
+                  "uncompressed-sha256": "3af2bedfdcedf09d0440e3e69921cc1f7eadad674384abfe090a0cfd449dd049"
+                }
+              }
+            }
+          },
+          "openstack": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-openstack.s390x.qcow2.gz",
+                  "sha256": "5038f843e5b51834f553acb4ec7402025c9e8dacb98dbb6c104fb5f88cacbd09",
+                  "uncompressed-sha256": "0ec38edf8d31be1d7d6e3b52c4fde98588d8cbfd71e02036a702c925bf36557a"
+                }
+              }
+            }
+          },
+          "qemu": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-qemu.s390x.qcow2.gz",
+                  "sha256": "b153ea128f33558aea82b28f426f4cf97b0a029a96fb36da3fc7cc791e8f8fc0",
+                  "uncompressed-sha256": "5a6fd94e23cd2afdd33ec30e1826e325f93b081ba38e67a877160d3cf1940e64"
+                }
+              }
+            }
+          },
+          "qemu-secex": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/s390x/rhcos-10.2.20260521-0-qemu-secex.s390x.qcow2.gz",
+                  "sha256": "b3a8ea547b2e968ebac26783852f480dec3d9c551c8cf0dc3518d468a23671f8",
+                  "uncompressed-sha256": "29e252f6217ff359892f380709644576ed5092be7467cc9dc3f41ed8bdbd194d"
+                }
+              }
+            }
+          }
+        },
+        "images": {
+          "kubevirt": {
+            "release": "10.2.20260521-0",
+            "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-10.2-coreos-kubevirt",
+            "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6860a903823f8456456a0b9eb987ac2a3572745d05903c610e6ba9dde7470438"
+          }
+        }
+      },
+      "x86_64": {
+        "artifacts": {
+          "aws": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "vmdk.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-aws.x86_64.vmdk.gz",
+                  "sha256": "1a276abe6dd0028afbd58474aa7931a1edfd99d4a604876f694d2f225eafdea2",
+                  "uncompressed-sha256": "32029b2027c407600ff99986f56208a90beac6a6aefae62b176f64988922977a"
+                }
+              }
+            }
+          },
+          "azure": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "vhd.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-azure.x86_64.vhd.gz",
+                  "sha256": "6b496cff802fb70f227ba1f4b54ed1c14a4a496588fb289618ef30e8b163202e",
+                  "uncompressed-sha256": "d76b8aa8c9914574827db379574b24aa843c68260df18930e50f239c3dde214a"
+                }
+              }
+            }
+          },
+          "azurestack": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "vhd.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-azurestack.x86_64.vhd.gz",
+                  "sha256": "21a2aa626358f2a59917320a241650e02243221b8e967d849f28f795a81576f1",
+                  "uncompressed-sha256": "d6f7e118d43f59c3475b49b6d7f0ac8530067bafe894c7d543d26ce91ef43233"
+                }
+              }
+            }
+          },
+          "gcp": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "tar.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-gcp.x86_64.tar.gz",
+                  "sha256": "0d2ba5058178683bc549a3068ee81f25c2f4f638b8f2e93ad7e8e591ccb261d3"
+                }
+              }
+            }
+          },
+          "ibmcloud": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-ibmcloud.x86_64.qcow2.gz",
+                  "sha256": "011c1686fec24c9e9993e2f01fa18b2b59238a609896332dc1858bd6af640b32",
+                  "uncompressed-sha256": "6af62dc4d00ebf96ec37e5532089efd826574bc667909e21b801955483bee66a"
+                }
+              }
+            }
+          },
+          "kubevirt": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "ociarchive": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-kubevirt.x86_64.ociarchive",
+                  "sha256": "a414bec70e6ad56fbdc52f6314f0c0c3a157390b14106a7fb532e50277adcc0b"
+                }
+              }
+            }
+          },
+          "metal": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "4k.raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-metal4k.x86_64.raw.gz",
+                  "sha256": "d22a49c34fe481a2b488cf2b8045e974f41b056d52a961d434176872cfbfa830",
+                  "uncompressed-sha256": "3a96c60a6520fe5cd894cf7f4618ace15e2aefefed8960ac9394c8f31d770b97"
+                }
+              },
+              "iso": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-live-iso.x86_64.iso",
+                  "sha256": "2391c8f0d86b6c14aa9ce02c866af109f360a162ddcdb7e3f5a76eb3a7238b6d"
+                }
+              },
+              "pxe": {
+                "kernel": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-live-kernel.x86_64",
+                  "sha256": "62f6c048aef362c496f6f7cd3b0bb07d9a648fbacb212e2d1951979dcbe72f75"
+                },
+                "initramfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-live-initramfs.x86_64.img",
+                  "sha256": "488c4d0f71641de54a54795d594337c8c7d12c1dabb2c3c1de1b87f75b42b97d"
+                },
+                "rootfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-live-rootfs.x86_64.img",
+                  "sha256": "9651ccaa3c5d99f037368507cd4a56b85d53932613a3b335bbdc4caedb362793"
+                }
+              },
+              "raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-metal.x86_64.raw.gz",
+                  "sha256": "5c8483811f6ad487b0bed7b00d5a4cc6a72add05b67e0dd4e02d21172e19df83",
+                  "uncompressed-sha256": "1061cb3e69b59f5cb27bce34698b8e9e8720d6ff6b2610679375fa1d03af953f"
+                }
+              }
+            }
+          },
+          "nutanix": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-nutanix.x86_64.qcow2",
+                  "sha256": "5fd345509ef66685fbdc04bef9eec5198e58f0cc77750d7c7712610684c5b020"
+                }
+              }
+            }
+          },
+          "openstack": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-openstack.x86_64.qcow2.gz",
+                  "sha256": "763fa94cb70d8543983eb4e15bf154d2bd72d8ffc227ab0b0a210d7d591a022d",
+                  "uncompressed-sha256": "a6c820cd306f0112c148d62b4f72581741a79206d6dcd1b186f28008c139f66f"
+                }
+              }
+            }
+          },
+          "qemu": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-qemu.x86_64.qcow2.gz",
+                  "sha256": "5b6eb490d8dba2c3057d39498e397509ca3435fcf7be70ee084fb08739a186ef",
+                  "uncompressed-sha256": "c5e3ad16c520b75c75025eb7c06f12d2242281683938d11a43bdabba04dc5ebb"
+                }
+              }
+            }
+          },
+          "vmware": {
+            "release": "10.2.20260521-0",
+            "formats": {
+              "ova": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-10.2/builds/10.2.20260521-0/x86_64/rhcos-10.2.20260521-0-vmware.x86_64.ova",
+                  "sha256": "ee4fd4d7f2d96a5e72344a03a8aacd0c81c0e24f4fec6983dbf3639f241180d3"
+                }
+              }
+            }
+          }
+        },
+        "images": {
+          "aws": {
+            "regions": {
+              "af-south-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-00b9419956a1b8301"
+              },
+              "ap-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-093ce74a7831d5796"
+              },
+              "ap-east-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0f1f5f78fad6126f3"
+              },
+              "ap-northeast-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0b1305ab18da2b503"
+              },
+              "ap-northeast-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-089d5b21fb5472656"
+              },
+              "ap-northeast-3": {
+                "release": "10.2.20260521-0",
+                "image": "ami-08b988fa11f0772c3"
+              },
+              "ap-south-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-030c986c15d7d21fe"
+              },
+              "ap-south-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0baf89a420726a0c9"
+              },
+              "ap-southeast-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-07db2a2569bf635d5"
+              },
+              "ap-southeast-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0c66ca97b4cb72a96"
+              },
+              "ap-southeast-3": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0ea4633b5accce1cc"
+              },
+              "ap-southeast-4": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0b9a19c6d404ebe82"
+              },
+              "ap-southeast-5": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0860196faab6d36f5"
+              },
+              "ap-southeast-6": {
+                "release": "10.2.20260521-0",
+                "image": "ami-05391d944831d449c"
+              },
+              "ap-southeast-7": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0ea7c99fe14478e31"
+              },
+              "ca-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-01a1c5433b11c6040"
+              },
+              "ca-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0aaec38c9c3c18973"
+              },
+              "eu-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-050a2036417aa85c9"
+              },
+              "eu-central-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0dc1cab1a5a382089"
+              },
+              "eu-north-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0ebb900e33852ac20"
+              },
+              "eu-south-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-06794550da69b4d4f"
+              },
+              "eu-south-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-09b9b2363f8b9bf79"
+              },
+              "eu-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-00277e2896ce030cd"
+              },
+              "eu-west-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-06c08d05f6a1085e5"
+              },
+              "eu-west-3": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0c94bd2324f9a7dc4"
+              },
+              "il-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-090c5d273c266bcb1"
+              },
+              "mx-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0127400b1a4f4d8a8"
+              },
+              "sa-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0d636038b33e48e74"
+              },
+              "us-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-06c799e44545e8040"
+              },
+              "us-east-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0b56c6461b8dfea32"
+              },
+              "us-gov-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-00a5a8f684bfe21a4"
+              },
+              "us-gov-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0ee3e9e7a587954c3"
+              },
+              "us-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0ceb35adb65ceb3ee"
+              },
+              "us-west-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0a8a99e4004c7938d"
+              }
+            }
+          },
+          "gcp": {
+            "release": "10.2.20260521-0",
+            "project": "rhcos-cloud",
+            "name": "rhcos-10-2-20260521-0-gcp-x86-64"
+          },
+          "kubevirt": {
+            "release": "10.2.20260521-0",
+            "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-10.2-coreos-kubevirt",
+            "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:aec3a148abce32bebabb41bfb65a3f129ca3d8ef05a9cf904c6b0de814837d6f"
+          }
+        },
+        "rhel-coreos-extensions": {
+          "aws-winli": {
+            "regions": {
+              "af-south-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-04629785741cd0c85"
+              },
+              "ap-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-04e7b5cda044a345b"
+              },
+              "ap-east-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-09597825db0fdfd3b"
+              },
+              "ap-northeast-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0a55ac6f11719c822"
+              },
+              "ap-northeast-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-08b646066f246736b"
+              },
+              "ap-northeast-3": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0f736787bf849916b"
+              },
+              "ap-south-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-06fe750217b18f5fc"
+              },
+              "ap-south-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0690504f72e3b04c0"
+              },
+              "ap-southeast-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-01bad64fdf89571fc"
+              },
+              "ap-southeast-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-025c7ec136eb0cbf8"
+              },
+              "ap-southeast-3": {
+                "release": "10.2.20260521-0",
+                "image": "ami-03c8c75788294dba7"
+              },
+              "ap-southeast-4": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0f70c9b515dd1a3b1"
+              },
+              "ap-southeast-5": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0f8c0d70e09800f21"
+              },
+              "ap-southeast-6": {
+                "release": "10.2.20260521-0",
+                "image": "ami-043fa8fbc9b96d662"
+              },
+              "ap-southeast-7": {
+                "release": "10.2.20260521-0",
+                "image": "ami-04e24a754fa786364"
+              },
+              "ca-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-03b7a55496c42fc63"
+              },
+              "ca-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0a80835b7278dc187"
+              },
+              "eu-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-02338882f5dafcfc4"
+              },
+              "eu-central-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-04863e0aebc2f44b7"
+              },
+              "eu-north-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0e73038567e8437e4"
+              },
+              "eu-south-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0931fa534f93a042f"
+              },
+              "eu-south-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0fc02e1bd72841712"
+              },
+              "eu-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0182cecfd8a730b77"
+              },
+              "eu-west-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0348960515ef650db"
+              },
+              "eu-west-3": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0bf738ff0aa9bcab8"
+              },
+              "il-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-09d3310d723b575c2"
+              },
+              "mx-central-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0d01c8db5fe377d0a"
+              },
+              "sa-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0df670278a153b916"
+              },
+              "us-east-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-025b0888df6c921ee"
+              },
+              "us-east-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0d7cc58bab2be7cbb"
+              },
+              "us-west-1": {
+                "release": "10.2.20260521-0",
+                "image": "ami-0f0c99139c39f0f5b"
+              },
+              "us-west-2": {
+                "release": "10.2.20260521-0",
+                "image": "ami-08e35831290bf6e10"
+              }
+            }
+          },
+          "azure-disk": {
+            "release": "10.2.20260521-0",
+            "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-10.2.20260521-0-azure.x86_64.vhd"
+          }
+        }
+      }
+    }
+  }

--- a/tests/coreos/data/coreos-rhel-9.json
+++ b/tests/coreos/data/coreos-rhel-9.json
@@ -1,0 +1,978 @@
+{
+    "stream": "rhcos-4.21",
+    "metadata": {
+      "last-modified": "2026-05-26T02:01:01Z",
+      "generator": "plume cosa2stream 5f75da4"
+    },
+    "architectures": {
+      "aarch64": {
+        "artifacts": {
+          "aws": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "vmdk.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-aws.aarch64.vmdk.gz",
+                  "sha256": "babb75e4dd4a81aeed3b4fe343b8b24511e8e959858d065b3cd86d8e97ec6a65",
+                  "uncompressed-sha256": "80d6a781ec13b07ffa8b44ee46ed0d7d3bc7bc747650be8bb03d63bbc8b0d547"
+                }
+              }
+            }
+          },
+          "azure": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "vhd.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-azure.aarch64.vhd.gz",
+                  "sha256": "8079d31ae4f745ba6c2c5da8bafba7d0f3db1691393ebbbb8f995c915ad9a04d",
+                  "uncompressed-sha256": "a934425896ec87d313377b5391d23e7da29a3e9e3b80b486a4b1c10fbeae7793"
+                }
+              }
+            }
+          },
+          "gcp": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "tar.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-gcp.aarch64.tar.gz",
+                  "sha256": "9d88450d80e9d5b14572e595296d8e26321b2f80e6c9f3138c8be13db23c170e"
+                }
+              }
+            }
+          },
+          "metal": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "4k.raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-metal4k.aarch64.raw.gz",
+                  "sha256": "fd7aefc04a05c496f270e1e3958c4955e567dcba00c589e4dc456b720566c87f",
+                  "uncompressed-sha256": "73e8d2c4ba2f5a2835b7d6b15f7ddfe4c02ba8a74cb1018ae73e44db43f4b940"
+                }
+              },
+              "iso": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-live-iso.aarch64.iso",
+                  "sha256": "a7f66f1dd3eca61713a2fa8893f28c4afc1afd4c98993c9ffe6b3ef2a3059bf9"
+                }
+              },
+              "pxe": {
+                "kernel": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-live-kernel.aarch64",
+                  "sha256": "6c888d8ff349fe44c347bcad2bc7cb7fa6abc2f5297d8b5e8b1564c65c9c682c"
+                },
+                "initramfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-live-initramfs.aarch64.img",
+                  "sha256": "e8d315ab836e8712f19b73672f1d435017a3cf37d64c8e0b511e41c1c3578450"
+                },
+                "rootfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-live-rootfs.aarch64.img",
+                  "sha256": "e791fc8eced9fc65b012cace13689a1d13cfacd2c42334188a634f358c64e975"
+                }
+              },
+              "raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-metal.aarch64.raw.gz",
+                  "sha256": "8c95a89bfb6e80dbf695ad0f6dab40771705b3cd7138918ee217d808fabaea40",
+                  "uncompressed-sha256": "3c37094e9ce89291956d7bc037b0700b3618e610532c220a72c416d311b0dc50"
+                }
+              }
+            }
+          },
+          "nvidiabluefield": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "bfb": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-nvidiabluefield.aarch64.bfb",
+                  "sha256": "d3a5458c03857021eaa748698e4116ac33a2dfc850f4895b6d5181da884f1439"
+                }
+              }
+            }
+          },
+          "openstack": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-openstack.aarch64.qcow2.gz",
+                  "sha256": "12e8bdd0112dda5d19428a6b8799f76312bb27ffc893b991a950abd331616426",
+                  "uncompressed-sha256": "bc4fec3f06c24fc48c6171a9d4df37d679dae7ffd7b187e769b46837fba1b3fb"
+                }
+              }
+            }
+          },
+          "qemu": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/aarch64/rhcos-9.8.20260520-0-qemu.aarch64.qcow2.gz",
+                  "sha256": "ec850a9b055cac5f38b49375464ea14b30058e136be39c935ad7e90b298ed38c",
+                  "uncompressed-sha256": "875e0213b3d2a4cc120567f3084177033627b75d35d0562802b7c8b870bac424"
+                }
+              }
+            }
+          }
+        },
+        "images": {
+          "aws": {
+            "regions": {
+              "af-south-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-09b3b126662fe7a18"
+              },
+              "ap-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-009fe8f4f06381d2e"
+              },
+              "ap-east-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0403657dcda8a5e9c"
+              },
+              "ap-northeast-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0f9d02af671b8f84e"
+              },
+              "ap-northeast-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-09fb79703d81dad43"
+              },
+              "ap-northeast-3": {
+                "release": "9.8.20260520-0",
+                "image": "ami-038a507ec93b04ce1"
+              },
+              "ap-south-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0eb4f5b5dbaa33c62"
+              },
+              "ap-south-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0d0f18aae857f459b"
+              },
+              "ap-southeast-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0519530b4a949ac79"
+              },
+              "ap-southeast-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-029b0ef4d6d0872e6"
+              },
+              "ap-southeast-3": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0e04bab1932cc8079"
+              },
+              "ap-southeast-4": {
+                "release": "9.8.20260520-0",
+                "image": "ami-03b0fdc3fbc4a0fa4"
+              },
+              "ap-southeast-5": {
+                "release": "9.8.20260520-0",
+                "image": "ami-046fecd472297b7c4"
+              },
+              "ap-southeast-6": {
+                "release": "9.8.20260520-0",
+                "image": "ami-088024b57838dfd53"
+              },
+              "ap-southeast-7": {
+                "release": "9.8.20260520-0",
+                "image": "ami-00c84a187abf62194"
+              },
+              "ca-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0f65ba965f0cdf25b"
+              },
+              "ca-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0ce3bfdc385214b60"
+              },
+              "eu-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-077c9e69aa2a7442b"
+              },
+              "eu-central-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0843ce8434ed947e0"
+              },
+              "eu-north-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-047f81c57b0567e80"
+              },
+              "eu-south-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-048742ddf9599b9a3"
+              },
+              "eu-south-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0385fbca30108a3a9"
+              },
+              "eu-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-04631bbd6c1be5b55"
+              },
+              "eu-west-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0915a41744ba40397"
+              },
+              "eu-west-3": {
+                "release": "9.8.20260520-0",
+                "image": "ami-09fd8d0e79f45b71a"
+              },
+              "il-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0853f94ef8841751a"
+              },
+              "mx-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-039d2c56cbe869df0"
+              },
+              "sa-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0915393860fee75df"
+              },
+              "us-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0e3af3b58f5710e43"
+              },
+              "us-east-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-017020cb8aeeda203"
+              },
+              "us-gov-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-014a147dae2cf3359"
+              },
+              "us-gov-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-07113f5ee8cde6fb3"
+              },
+              "us-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-09ca10147735afd05"
+              },
+              "us-west-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-00e116f16409da3de"
+              }
+            }
+          },
+          "gcp": {
+            "release": "9.8.20260520-0",
+            "project": "rhcos-cloud",
+            "name": "rhcos-9-8-20260520-0-gcp-aarch64"
+          }
+        },
+        "rhel-coreos-extensions": {
+          "azure-disk": {
+            "release": "9.8.20260520-0",
+            "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260520-0-azure.aarch64.vhd"
+          }
+        }
+      },
+      "ppc64le": {
+        "artifacts": {
+          "metal": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "4k.raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-metal4k.ppc64le.raw.gz",
+                  "sha256": "facd7fc270bff93f8134da6d570fd9f43f2ad75dd3a3484087a37ffc63d1ed32",
+                  "uncompressed-sha256": "cdf6170ed2b8ba4fab15eca4206163caad1b356c81cdefd94492e6dde2bd0bf1"
+                }
+              },
+              "iso": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-live-iso.ppc64le.iso",
+                  "sha256": "5f7fa3a1b494a4ab5ebec1b510ca0f75fe16a7b6c62872f6d3be58ac32d1ce19"
+                }
+              },
+              "pxe": {
+                "kernel": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-live-kernel.ppc64le",
+                  "sha256": "90219684f62e0757f4c3480a1f80c24933fa111d77714c77609da112df1bc9b8"
+                },
+                "initramfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-live-initramfs.ppc64le.img",
+                  "sha256": "bbbe590182a5c010bd6fbfb2939b7ecaef7190be49324dc3a57bc4b53339f8a0"
+                },
+                "rootfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-live-rootfs.ppc64le.img",
+                  "sha256": "a89908555ce77be91e06bae735128d8f3fb0bfe9efdb2fc0d07e44cce098262b"
+                }
+              },
+              "raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-metal.ppc64le.raw.gz",
+                  "sha256": "f033a7001b5bd7c24bcb161d87edf1a0403d74031a52feb8099c6e3692115965",
+                  "uncompressed-sha256": "310a5da961a2c0e7bc6c2d451609b05b439bc6cbf6060e925d285b71832062cc"
+                }
+              }
+            }
+          },
+          "openstack": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-openstack.ppc64le.qcow2.gz",
+                  "sha256": "6ab344908e3ea34ee6bcd7b810533004eba259217a7730d36120383edd82aeb1",
+                  "uncompressed-sha256": "e5c50d5689ba92f68f8c5382f03eedbf12f8a31b3be9ae0e9c99242fb429cc9e"
+                }
+              }
+            }
+          },
+          "powervs": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "ova.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-powervs.ppc64le.ova.gz",
+                  "sha256": "ddb83d65656e88b9adde29d32c3a3181b9656f1eeed718d14eb07e1ce4268494",
+                  "uncompressed-sha256": "26779dad00883c64d11898ee10e14e508008deef65daf83f248371f344fc10d3"
+                }
+              }
+            }
+          },
+          "qemu": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/ppc64le/rhcos-9.8.20260520-0-qemu.ppc64le.qcow2.gz",
+                  "sha256": "0f79b8749924a5d74dd92f77fdd848033b5cc91eecad41f0aab527566cbd51c3",
+                  "uncompressed-sha256": "728aa75818a1c32e27969d2621aacbc077809013a3f87a6d79e322328c182d29"
+                }
+              }
+            }
+          }
+        },
+        "images": {
+          "powervs": {
+            "regions": {
+              "au-syd": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-au-syd",
+                "url": "https://s3.au-syd.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-au-syd/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              },
+              "br-sao": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-br-sao",
+                "url": "https://s3.br-sao.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-br-sao/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              },
+              "ca-tor": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-ca-tor",
+                "url": "https://s3.ca-tor.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-ca-tor/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              },
+              "eu-de": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-eu-de",
+                "url": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-de/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              },
+              "eu-es": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-eu-es",
+                "url": "https://s3.eu-es.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-es/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              },
+              "eu-gb": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-eu-gb",
+                "url": "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-eu-gb/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              },
+              "jp-osa": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-jp-osa",
+                "url": "https://s3.jp-osa.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-osa/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              },
+              "jp-tok": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-jp-tok",
+                "url": "https://s3.jp-tok.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-jp-tok/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              },
+              "us-east": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-us-east",
+                "url": "https://s3.us-east.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-east/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              },
+              "us-south": {
+                "release": "9.8.20260520-0",
+                "object": "rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz",
+                "bucket": "rhcos-powervs-images-us-south",
+                "url": "https://s3.us-south.cloud-object-storage.appdomain.cloud/rhcos-powervs-images-us-south/rhcos-9-8-20260520-0-ppc64le-powervs.ova.gz"
+              }
+            }
+          }
+        }
+      },
+      "s390x": {
+        "artifacts": {
+          "ibmcloud": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-ibmcloud.s390x.qcow2.gz",
+                  "sha256": "7c579dc338ad4436426071fca5741b8e0865e6ee005f112e2cf8c5e408f89cd1",
+                  "uncompressed-sha256": "4e84dfb034760345869400f8c55e86cf391450750c77df217ca95b1b98cba739"
+                }
+              }
+            }
+          },
+          "kubevirt": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "ociarchive": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-kubevirt.s390x.ociarchive",
+                  "sha256": "714779e1ab79e3d0ef3bd846c05ddecafc7023520561d62db836cb2c173c979a"
+                }
+              }
+            }
+          },
+          "metal": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "4k.raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-metal4k.s390x.raw.gz",
+                  "sha256": "8dce196544207435e19e18396f0f8b66f8e66b78fac5c2a2879a21aabd9275f7",
+                  "uncompressed-sha256": "6e7e1fd62515435188a2ddf7311f08abb837a6f7322a589e5a86b0047336f3a3"
+                }
+              },
+              "iso": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-live-iso.s390x.iso",
+                  "sha256": "5e97807bc3b835d4ccfe0948eb074e6b007541c523665da73cff0b029368a0ad"
+                }
+              },
+              "pxe": {
+                "kernel": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-live-kernel.s390x",
+                  "sha256": "a102492869419aaa153dcb3acb71d60eaafd81de9a0c3bc228a606837d04974c"
+                },
+                "initramfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-live-initramfs.s390x.img",
+                  "sha256": "ad3b5107756f88ef914214c93019bc3f66e8dd11be803db50233de1fa8d861c1"
+                },
+                "rootfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-live-rootfs.s390x.img",
+                  "sha256": "8994ca03a0465335867b7d8e2f5effef90cbc09e450f19a3d400a538f4a43d40"
+                }
+              },
+              "raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-metal.s390x.raw.gz",
+                  "sha256": "340b827b050891d018851ff189443070d0a02fe1692bed94540cd1ee6108b745",
+                  "uncompressed-sha256": "55c30b7ae036ab8517756647e3ed1491e7301404af032e867bd35ccf9d673001"
+                }
+              }
+            }
+          },
+          "openstack": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-openstack.s390x.qcow2.gz",
+                  "sha256": "633b7bd1a93eb82f98988c77143a82770988a134e772286e5ccbf937a014cdae",
+                  "uncompressed-sha256": "8b6d4f7e1f720d148faa8008345af067fa1b01331e6e0c53001e77a6233823ae"
+                }
+              }
+            }
+          },
+          "qemu": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-qemu.s390x.qcow2.gz",
+                  "sha256": "423427590eb9f62e0fc148665baebeb08f2f89197ea8131d263351d2951d0f78",
+                  "uncompressed-sha256": "e94c5b6f745df02dd61bd42f2cc533e582de20db0ee58b0b14b8548c4d1a4e78"
+                }
+              }
+            }
+          },
+          "qemu-secex": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/s390x/rhcos-9.8.20260520-0-qemu-secex.s390x.qcow2.gz",
+                  "sha256": "a2c67eaa121983fd57887bcd1433dd0d20991195e1b9ee7831a23e4784c46fdf",
+                  "uncompressed-sha256": "ea0861f09e19a87840b299a5575ec9360815380696984a0931b5cf19e3329b87"
+                }
+              }
+            }
+          }
+        },
+        "images": {
+          "kubevirt": {
+            "release": "9.8.20260520-0",
+            "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
+            "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:bcbee9a66fd77578c842adfc29e4f7b1e3433bd86290cc918f35047a9abf2055"
+          }
+        }
+      },
+      "x86_64": {
+        "artifacts": {
+          "aws": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "vmdk.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-aws.x86_64.vmdk.gz",
+                  "sha256": "997667d50ff8c33932c715879a6865bcd412d305fb63ce3d9a085c6f80b6dbe8",
+                  "uncompressed-sha256": "cee668d495aad654c948d81c55fec7b9fc49607f68cfc0cefb14e57b56e3d789"
+                }
+              }
+            }
+          },
+          "azure": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "vhd.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-azure.x86_64.vhd.gz",
+                  "sha256": "1fe5ef5bf54178f1f3013cf3841d37f21d878c56cfcb6b7d0487e0620beb7c64",
+                  "uncompressed-sha256": "51d5a7a48c773301dcadfad6e7f7e8cc5e2026d2420345540e8636a9386d0460"
+                }
+              }
+            }
+          },
+          "azurestack": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "vhd.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-azurestack.x86_64.vhd.gz",
+                  "sha256": "d0de38fb3061aa73b167250e3521ac6fe6409ff7a64f096b55e29d4029350ce1",
+                  "uncompressed-sha256": "d475515f6af8b7325dee679411523c376325b328ee06b30b78c5ca7d7dc8855e"
+                }
+              }
+            }
+          },
+          "gcp": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "tar.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-gcp.x86_64.tar.gz",
+                  "sha256": "632af30cc4a9d822983136fe5160df8964849ebceaf7886ace86e5c878e2d658"
+                }
+              }
+            }
+          },
+          "ibmcloud": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-ibmcloud.x86_64.qcow2.gz",
+                  "sha256": "3e8120aae1ceb68c4b6758d0b8d9b370b193ababd58cfe755a6805980a517ac1",
+                  "uncompressed-sha256": "9a6b73b6edb86411d69ac10a51973f715193a0bf6c8402cb60c3d78f3b9c49b8"
+                }
+              }
+            }
+          },
+          "kubevirt": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "ociarchive": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-kubevirt.x86_64.ociarchive",
+                  "sha256": "e4f06da6e30d03031678ce09c08657a44871ea422da9c8689bc26bd400000262"
+                }
+              }
+            }
+          },
+          "metal": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "4k.raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-metal4k.x86_64.raw.gz",
+                  "sha256": "ebf7c696b54bcdc45a443bc7829da3fe4530bf8a39223e3b6a5f4fc93b7fbca4",
+                  "uncompressed-sha256": "d5a6d1dd8b92d4eb9821d19409f15b81f411b2a2e8063d239600c56b35fadcdf"
+                }
+              },
+              "iso": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-live-iso.x86_64.iso",
+                  "sha256": "a5a4f5649f0dca87e381be07f40d2da10b6800b3e0d153c03a4ae441576e076d"
+                }
+              },
+              "pxe": {
+                "kernel": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-live-kernel.x86_64",
+                  "sha256": "1f0cfbf65799bc1e610433308393055360dbf9e772b37b1179bd70d55bfa8d16"
+                },
+                "initramfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-live-initramfs.x86_64.img",
+                  "sha256": "855fcdeb65fc74341a36383446805e2bc7fc43b0af9ef586ccf9a75078d21c88"
+                },
+                "rootfs": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-live-rootfs.x86_64.img",
+                  "sha256": "77836ae027501853e4e84f6cd74d72c6d30d3287918aa3faec995685d4cfc850"
+                }
+              },
+              "raw.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-metal.x86_64.raw.gz",
+                  "sha256": "e273adc5c8da35b99c9b60bf850674b37657e7db8cadee691824c961947cc707",
+                  "uncompressed-sha256": "0a620d1fdb9725c0e8c8ba9db67743149f9e2b9d0353b07f20ef6096a97194b1"
+                }
+              }
+            }
+          },
+          "nutanix": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-nutanix.x86_64.qcow2",
+                  "sha256": "f89efa4d668129f982f75b17913796b68f285b65a79c18f0ab62816bbd1256d3"
+                }
+              }
+            }
+          },
+          "openstack": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-openstack.x86_64.qcow2.gz",
+                  "sha256": "cbe1fed8954394f1429703f787a24abd37c712a58c4f93b53a5b05519ba8d455",
+                  "uncompressed-sha256": "2d373472a1dbe7e54f76fd2f1d3604a57be1f398aef53cf154e5912d3a66f482"
+                }
+              }
+            }
+          },
+          "qemu": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "qcow2.gz": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-qemu.x86_64.qcow2.gz",
+                  "sha256": "eb7eefd2f518a44745fa6e435912f7f5028f92adc52e41b4e2b06dd10cf1f6dd",
+                  "uncompressed-sha256": "b3fda398884317472bdf50b70f760b57f2aaf41962f9572488a8a81e0ac85894"
+                }
+              }
+            }
+          },
+          "vmware": {
+            "release": "9.8.20260520-0",
+            "formats": {
+              "ova": {
+                "disk": {
+                  "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/rhel-9.8/builds/9.8.20260520-0/x86_64/rhcos-9.8.20260520-0-vmware.x86_64.ova",
+                  "sha256": "160f7b0395f849fb8056f3b4de23c2ecb396efc6cb52cb954799388afaf1fd5a"
+                }
+              }
+            }
+          }
+        },
+        "images": {
+          "aws": {
+            "regions": {
+              "af-south-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0e09db1a117f89982"
+              },
+              "ap-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0f3883046e2b590c4"
+              },
+              "ap-east-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-05fda30c28d357b97"
+              },
+              "ap-northeast-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0acebf7451fbed435"
+              },
+              "ap-northeast-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-07e85fe3474ab6f53"
+              },
+              "ap-northeast-3": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0bf06ecbd16316390"
+              },
+              "ap-south-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-001b087fae6b102a2"
+              },
+              "ap-south-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-02e59bb73395086de"
+              },
+              "ap-southeast-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-07e0e4d66f0276e33"
+              },
+              "ap-southeast-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0656ee074d43ebeb9"
+              },
+              "ap-southeast-3": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0b8ac3107bf7b8091"
+              },
+              "ap-southeast-4": {
+                "release": "9.8.20260520-0",
+                "image": "ami-06a85e79ca82e97d3"
+              },
+              "ap-southeast-5": {
+                "release": "9.8.20260520-0",
+                "image": "ami-068e811f466ce5eec"
+              },
+              "ap-southeast-6": {
+                "release": "9.8.20260520-0",
+                "image": "ami-01801dc800c336d1f"
+              },
+              "ap-southeast-7": {
+                "release": "9.8.20260520-0",
+                "image": "ami-01b449b1bf9c95caf"
+              },
+              "ca-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-016a214bc34aed24c"
+              },
+              "ca-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0279542db8d76fe7c"
+              },
+              "eu-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-02b4be39da643ac06"
+              },
+              "eu-central-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-09e9173753792f284"
+              },
+              "eu-north-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0b4a484d5db49d4a5"
+              },
+              "eu-south-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-02f2692568ca70d48"
+              },
+              "eu-south-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0777de9170dd480a0"
+              },
+              "eu-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0754b5979bce4f62f"
+              },
+              "eu-west-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-05a2b3abb8cf0cc92"
+              },
+              "eu-west-3": {
+                "release": "9.8.20260520-0",
+                "image": "ami-01ba91ba1e67b52fa"
+              },
+              "il-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0be1e841b9475abc2"
+              },
+              "mx-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-04e5e190abb398aef"
+              },
+              "sa-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-09b6c03d247ba3007"
+              },
+              "us-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-09a04cae40b5df1b1"
+              },
+              "us-east-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-008f91aec6651d818"
+              },
+              "us-gov-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-083a079a4e93810d0"
+              },
+              "us-gov-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-03c270b5f712d93c5"
+              },
+              "us-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-000065c53330c76d2"
+              },
+              "us-west-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0106a1d635d4a36c0"
+              }
+            }
+          },
+          "gcp": {
+            "release": "9.8.20260520-0",
+            "project": "rhcos-cloud",
+            "name": "rhcos-9-8-20260520-0-gcp-x86-64"
+          },
+          "kubevirt": {
+            "release": "9.8.20260520-0",
+            "image": "quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-9.8-coreos-kubevirt",
+            "digest-ref": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:024cb7de8d9e21ef7fc2bcb90f8dd77e7f742d937822c95e4ec72b9ab48fea7d"
+          }
+        },
+        "rhel-coreos-extensions": {
+          "aws-winli": {
+            "regions": {
+              "af-south-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0f714f6517c9d016f"
+              },
+              "ap-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0577eeeae04d22229"
+              },
+              "ap-east-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0292a0a795c3f3d41"
+              },
+              "ap-northeast-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0a4a58bace1eec1bf"
+              },
+              "ap-northeast-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-024f9af412e8e5fda"
+              },
+              "ap-northeast-3": {
+                "release": "9.8.20260520-0",
+                "image": "ami-062da8b605d19e1f0"
+              },
+              "ap-south-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-06c9a5797035f6ec5"
+              },
+              "ap-south-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-006a3ba40b81e7e68"
+              },
+              "ap-southeast-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-02d836c02d12549da"
+              },
+              "ap-southeast-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-05ef34bbc717783b5"
+              },
+              "ap-southeast-3": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0ef2955291a017868"
+              },
+              "ap-southeast-4": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0698dbb27842933e5"
+              },
+              "ap-southeast-5": {
+                "release": "9.8.20260520-0",
+                "image": "ami-053a4e24d78ed0d67"
+              },
+              "ap-southeast-6": {
+                "release": "9.8.20260520-0",
+                "image": "ami-07ca2f504ecb9314f"
+              },
+              "ap-southeast-7": {
+                "release": "9.8.20260520-0",
+                "image": "ami-05bf98f73e9241182"
+              },
+              "ca-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0c3338c7efad3ec9a"
+              },
+              "ca-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0992376ec4897fc46"
+              },
+              "eu-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-036c68d29575b583e"
+              },
+              "eu-central-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0f19f652bb725f295"
+              },
+              "eu-north-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0055f4b25c33781ab"
+              },
+              "eu-south-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0e72c26fb402fbe28"
+              },
+              "eu-south-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-07f86962840bf77e4"
+              },
+              "eu-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0ad984e0dd8c08040"
+              },
+              "eu-west-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0be3668bd2cafc141"
+              },
+              "eu-west-3": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0c2c852546612d7e6"
+              },
+              "il-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-05229890b9fc0e77f"
+              },
+              "mx-central-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0862a29bb196d26ed"
+              },
+              "sa-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-05dd182f06c736610"
+              },
+              "us-east-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-08298b57bfd602d1b"
+              },
+              "us-east-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-0245c7e4c6c909c70"
+              },
+              "us-west-1": {
+                "release": "9.8.20260520-0",
+                "image": "ami-015f92b61a17c928d"
+              },
+              "us-west-2": {
+                "release": "9.8.20260520-0",
+                "image": "ami-01ca3b6c80acda171"
+              }
+            }
+          },
+          "azure-disk": {
+            "release": "9.8.20260520-0",
+            "url": "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260520-0-azure.x86_64.vhd"
+          }
+        }
+      }
+    }
+  }

--- a/tests/coreos/test_coreos_client.py
+++ b/tests/coreos/test_coreos_client.py
@@ -1,0 +1,83 @@
+import json
+from unittest import mock
+
+from pushsource._impl.backend.coreos_source.coreos_client import CoreOSClient
+
+
+class TestCoreOSClient:
+    def test_convert_github_blob_to_raw(self):
+        expected_raw_url = "https://raw.githubusercontent.com/openshift/installer/master/data/data/coreos/rhcos.json"
+        actual_raw_url = CoreOSClient.convert_github_blob_to_raw(
+            "https://github.com/openshift/installer/tree/master",
+            "data/data/coreos/rhcos.json",
+        )
+        assert actual_raw_url == expected_raw_url
+
+        non_github_url = "https://example.com/some/path/file.json"
+        actual_raw_url = CoreOSClient.convert_github_blob_to_raw(
+            "https://example.com/some/path", "file.json"
+        )
+        assert actual_raw_url == "https://example.com/some/path/file.json"
+
+    def test_shutdown(self, mock_coreos_client):
+        with mock.patch.object(
+            mock_coreos_client._executor, "shutdown"
+        ) as mock_shutdown:
+            mock_coreos_client.shutdown()
+            mock_shutdown.assert_called_once_with(True)
+
+    def test_get_json_f(self, mock_coreos_client):
+        with mock.patch.object(mock_coreos_client, "_do_request") as mock_do_request:
+            # Test successful JSON decoding
+            mock_response_success = mock.Mock()
+            mock_response_success.json.return_value = {"key": "value"}
+            mock_response_success.raise_for_status.return_value = None
+            mock_do_request.return_value = mock_response_success
+
+            test_url = "https://raw.githubusercontent.com/openshift/installer/master/data/data/coreos/test.json"
+            mock_coreos_client.convert_github_blob_to_raw = (
+                lambda base_url, path: test_url
+            )
+
+            future = mock_coreos_client.get_json_f("data/data/coreos/test.json")
+            result = future.result()
+            assert result == {"key": "value"}
+            mock_do_request.assert_called_once_with(method="GET", url=test_url)
+
+            # Test JSONDecodeError handling
+            mock_do_request.reset_mock()
+            mock_response_json_error = mock.Mock()
+            mock_response_json_error.json.side_effect = json.JSONDecodeError(
+                "msg", "doc", 0
+            )
+            mock_response_json_error.raise_for_status.return_value = None
+            mock_do_request.return_value = mock_response_json_error
+
+            future_error = mock_coreos_client.get_json_f("data/data/coreos/test.json")
+            result_error = future_error.result()
+            assert result_error is None
+            mock_do_request.assert_called_once_with(method="GET", url=test_url)
+
+    def test_session_property_initialization(self, mock_coreos_client):
+        # Ensure session is created only once per thread
+        # First access, session should be created
+        session1 = mock_coreos_client._session
+        with mock.patch("requests.Session") as mock_session_class:
+            # Second access, session should not be created again
+            session2 = mock_coreos_client._session
+            mock_session_class.assert_not_called()  # Should not be called again
+            assert session1 is session2
+
+    def test_do_request(self, mock_coreos_client):
+        # Ensure _tls.session is initialized
+        _ = mock_coreos_client._session
+        with mock.patch.object(mock_coreos_client._tls, "session") as mock_session:
+            mock_response = mock.Mock()
+            mock_session.request.return_value = mock_response
+
+            method = "GET"
+            url = "http://example.com/api"
+            result = mock_coreos_client._do_request(method, url)
+
+            mock_session.request.assert_called_once_with(method, url)
+            assert result == mock_response

--- a/tests/coreos/test_coreos_source.py
+++ b/tests/coreos/test_coreos_source.py
@@ -1,0 +1,141 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from pushsource._impl.backend.coreos_source.coreos_source import CoreOSSource
+from pushsource._impl.model import AmiPushItem, VHDPushItem
+from pushsource._impl.model.ami import AmiRelease
+from pushsource._impl.model.vms import VMIRelease
+from pushsource._impl.source import Source
+
+
+class TestCoreOSSource:
+    @pytest.fixture
+    def coreos_source(self, mock_coreos_client):
+        source = CoreOSSource(
+            url="https://github.com/openshift/installer/tree/master",
+            paths=["data/coreos-rhel-9.json"],
+        )
+        source._client = mock_coreos_client
+        return source
+
+    @pytest.fixture
+    def coreos_source_with_paths(self, mock_coreos_client, request):
+        source = CoreOSSource(
+            url="https://github.com/openshift/installer/tree/master",
+            paths=request.param,
+        )
+        source._client = mock_coreos_client
+        return source
+
+    def test_push_items_from_json_rhel9(self, requests_mock, coreos_rhel_9_data):
+        test_url_base = "https://github.com/openshift/installer/tree/master"
+        test_url_raw = "https://raw.githubusercontent.com/openshift/installer/master"
+        test_path = "data/coreos-rhel-9.json"
+
+        # Mock the request to the raw JSON file
+        requests_mock.get(f"{test_url_raw}/{test_path}", json=coreos_rhel_9_data)
+
+        # Get the source and iterate through push items
+        with Source.get("coreos:%s" % test_url_base, paths=[test_path]) as source:
+            push_items = [item for item in source]
+
+        assert requests_mock.called
+
+        assert len(push_items) == 70
+
+        # Test AWS AMI Push Item
+        aws_ami_item = next(
+            (
+                item
+                for item in push_items
+                if isinstance(item, AmiPushItem)
+                and item.marketplace_name == "aws"
+                and item.release.arch == "aarch64"
+            ),
+            None,
+        )
+        assert aws_ami_item is not None
+        assert aws_ami_item.name == "rhcos"
+        assert aws_ami_item.description.startswith("CoreOS image for rhcos 4.21 on aws")
+        assert aws_ami_item.region == "af-south-1"
+        assert aws_ami_item.src == "ami-09b3b126662fe7a18"
+        assert isinstance(aws_ami_item.release, AmiRelease)
+        assert aws_ami_item.release.arch == "aarch64"
+        assert aws_ami_item.release.product == "RHCOS"
+        assert aws_ami_item.release.version == "4.21"
+        assert aws_ami_item.release.respin == 0
+        assert aws_ami_item.release.date == datetime(2026, 5, 26, 2, 1, 1)
+
+    def test_push_items_from_json_missing_data(
+        self, requests_mock, coreos_missing_data
+    ):
+        test_url_base = "https://github.com/openshift/installer/tree/master"
+        test_url_raw = "https://raw.githubusercontent.com/openshift/installer/master"
+        test_path = "data/coreos-missing-data.json"
+
+        # Mock the request to the raw JSON file
+        requests_mock.get(f"{test_url_raw}/{test_path}", json=coreos_missing_data)
+
+        # Get the source and iterate through push items
+        with Source.get("coreos:%s" % test_url_base, paths=[test_path]) as source:
+            push_items = [item for item in source]
+
+        assert requests_mock.called
+
+        # Expected behavior for missing stream/metadata: name, version will be empty, date will be current date
+        assert len(push_items) == 2
+
+        # Test AWS AMI Push Item with missing data
+        aws_ami_item = next(
+            (
+                item
+                for item in push_items
+                if isinstance(item, AmiPushItem)
+                and item.marketplace_name == "aws"
+                and item.release.arch == "aarch64"
+            ),
+            None,
+        )
+        assert aws_ami_item is not None
+        assert aws_ami_item.name == "unknown"
+        assert aws_ami_item.description.startswith(
+            "CoreOS image for unknown unknown on aws"
+        )
+        assert aws_ami_item.region == "af-south-1"
+        assert aws_ami_item.src == "ami-09b3b126662fe7a18"
+        assert isinstance(aws_ami_item.release, AmiRelease)
+        assert aws_ami_item.release.arch == "aarch64"
+        assert aws_ami_item.release.product == "UNKNOWN"
+        assert aws_ami_item.release.version == "unknown"
+        assert aws_ami_item.release.respin == 0
+        assert isinstance(aws_ami_item.release.date, datetime)
+        assert aws_ami_item.release.date.tzinfo == timezone.utc
+
+        # Test Azure VHD Push Item with missing data
+        azure_vhd_item = next(
+            (
+                item
+                for item in push_items
+                if isinstance(item, VHDPushItem)
+                and item.marketplace_name == "azure"
+                and item.release.arch == "aarch64"
+            ),
+            None,
+        )
+        assert azure_vhd_item is not None
+        assert azure_vhd_item.name == "unknown"
+        assert azure_vhd_item.description.startswith(
+            "CoreOS image for unknown unknown on azure"
+        )
+        assert (
+            azure_vhd_item.src
+            == "https://rhcos.blob.core.windows.net/imagebucket/rhcos-9.8.20260520-0-azure.aarch64.vhd"
+        )
+        assert isinstance(azure_vhd_item.release, VMIRelease)
+        assert azure_vhd_item.release.arch == "aarch64"
+        assert azure_vhd_item.release.product == "UNKNOWN"
+        assert azure_vhd_item.release.version == "unknown"
+        assert azure_vhd_item.release.respin == 0
+        assert isinstance(azure_vhd_item.release.date, datetime)
+        assert azure_vhd_item.release.date.tzinfo == timezone.utc


### PR DESCRIPTION
This commit adds a new source type named "coreos" which is capable of fetching push items from the openshift installer JSON in GitHub.

With this, it's possible to yield `AMIPushItem` and `VHDPushItem` from the installer, as shown in the example below:

```
pushsource-ls "coreos:https://github.com/openshift/installer/tree/release-4.22?paths=data/data/coreos/coreos-rhel-10.json"
```

The new entrypoint also support multiple paths, as shown below:

```
pushsource-ls "coreos:https://github.com/openshift/installer/tree/release-4.22?paths=data/data/coreos/coreos-rhel-9.json,data/data/coreos/coreos-rhel-10.json"
```

This is part of an effort to unblock the releases of new OpenShift versions (greater than v4.19)

Signed-off-by: Jonathan Gangi <jgangi@redhat.com>

Assisted-by: Cursor